### PR TITLE
Disable complex hipGraphDestroyNode tests

### DIFF
--- a/catch/hipTestMain/config/config_amd_linux_common.json
+++ b/catch/hipTestMain/config/config_amd_linux_common.json
@@ -14,6 +14,9 @@
 	   "Unit_hipInit_Negative",
 	   "Unit_hipMemset_Negative_OutOfBoundsPtr",
 	   "Unit_hipDeviceReset_Positive_Basic",
-	   "Unit_hipDeviceReset_Positive_Threaded"
+	   "Unit_hipDeviceReset_Positive_Threaded",
+	   "Unit_hipGraphDestroyNode_Complx_ChkNumOfNodesNDep",
+	   "Unit_hipGraphDestroyNode_Complx_ChkNumOfNodesNDep_ClonedGrph",
+	   "Unit_hipGraphDestroyNode_Complx_ChkNumOfNodesNDep_ChldNode"
 	]
 }

--- a/catch/hipTestMain/config/config_amd_windows_common.json
+++ b/catch/hipTestMain/config/config_amd_windows_common.json
@@ -93,6 +93,9 @@
 	   "Note: needs to be enabled when streamPerThread issues are fixed",
 	   "Unit_hipStreamSynchronize_NullStreamAndStreamPerThread",
 	   "Note: intermittent Seg fault failure ",
-	   "Unit_hipGraphAddEventRecordNode_Functional_WithoutFlags"
+	   "Unit_hipGraphAddEventRecordNode_Functional_WithoutFlags",
+	   "Unit_hipGraphDestroyNode_Complx_ChkNumOfNodesNDep",
+	   "Unit_hipGraphDestroyNode_Complx_ChkNumOfNodesNDep_ClonedGrph",
+	   "Unit_hipGraphDestroyNode_Complx_ChkNumOfNodesNDep_ChldNode"
 	]
 }


### PR DESCRIPTION
Disable:
- Unit_hipGraphDestroyNode_Complx_ChkNumOfNodesNDep
- Unit_hipGraphDestroyNode_Complx_ChkNumOfNodesNDep_ClonedGrph
- Unit_hipGraphDestroyNode_Complx_ChkNumOfNodesNDep_ChldNode