### PR TITLE
Link tests to required libraries

### DIFF
--- a/catch/external/Catch2/cmake/Catch2/Catch.cmake
+++ b/catch/external/Catch2/cmake/Catch2/Catch.cmake
@@ -374,6 +374,8 @@ function(hip_add_exe_to_target)
     if(UNIX)
       set(_LINKER_LIBS ${_LINKER_LIBS} stdc++fs)
       set(_LINKER_LIBS ${_LINKER_LIBS} -ldl)
+      set(_LINKER_LIBS ${_LINKER_LIBS} pthread)
+      set(_LINKER_LIBS ${_LINKER_LIBS} rt)
     else()
       # res files are built resource files using rc files.
       # use llvm-rc exe to build the res files


### PR DESCRIPTION
A lot of the unit tests make use of the C++ thread library but the cmakefile doesn't explicitly link them to the pthread library but instead rely on hipcc to implicitly link in the pthread library. Some tests that rely on librt have a similar issue.  The tests break when we are cleaning up hipcc by removing the implcit linking to those libraries.