### PR TITLE
SWDEV-1 - Disable newly added failing tests

### DIFF
--- a/catch/hipTestMain/config/config_amd_linux_common.json
+++ b/catch/hipTestMain/config/config_amd_linux_common.json
@@ -19,12 +19,12 @@
 	   "Unit_hipGraphDestroyNode_Complx_ChkNumOfNodesNDep_ClonedGrph",
 	   "Unit_hipGraphDestroyNode_Complx_ChkNumOfNodesNDep_ChldNode",
 	   "Unit_hipMemGetAddressRange_Negative",
-       "Unit_hipMemRangeGetAttribute_Positive_AccessedBy_Basic",
-       "Unit_hipMemRangeGetAttribute_Positive_AccessedBy_Partial_Range",
-       "Unit_hipMemRangeGetAttributes_Negative_Parameters",
-       "Unit_hipStreamAttachMemAsync_Positive_Basic",
-       "Unit_hipStreamAttachMemAsync_Positive_AttachGlobal",
-       "Unit_hipStreamAttachMemAsync_Negative_Parameters",
-       "Unit_hipMemGetAddressRange_Positive"
+	   "Unit_hipMemRangeGetAttribute_Positive_AccessedBy_Basic",
+	   "Unit_hipMemRangeGetAttribute_Positive_AccessedBy_Partial_Range",
+	   "Unit_hipMemRangeGetAttributes_Negative_Parameters",
+	   "Unit_hipStreamAttachMemAsync_Positive_Basic",
+	   "Unit_hipStreamAttachMemAsync_Positive_AttachGlobal",
+	   "Unit_hipStreamAttachMemAsync_Negative_Parameters",
+	   "Unit_hipMemGetAddressRange_Positive"
 	]
 }

--- a/catch/hipTestMain/config/config_amd_linux_common.json
+++ b/catch/hipTestMain/config/config_amd_linux_common.json
@@ -18,6 +18,13 @@
 	   "Unit_hipGraphDestroyNode_Complx_ChkNumOfNodesNDep",
 	   "Unit_hipGraphDestroyNode_Complx_ChkNumOfNodesNDep_ClonedGrph",
 	   "Unit_hipGraphDestroyNode_Complx_ChkNumOfNodesNDep_ChldNode",
-	   "Unit_hipMemGetAddressRange_Negative"
+	   "Unit_hipMemGetAddressRange_Negative",
+       "Unit_hipMemRangeGetAttribute_Positive_AccessedBy_Basic",
+       "Unit_hipMemRangeGetAttribute_Positive_AccessedBy_Partial_Range",
+       "Unit_hipMemRangeGetAttributes_Negative_Parameters",
+       "Unit_hipStreamAttachMemAsync_Positive_Basic",
+       "Unit_hipStreamAttachMemAsync_Positive_AttachGlobal",
+       "Unit_hipStreamAttachMemAsync_Negative_Parameters",
+       "Unit_hipMemGetAddressRange_Positive"
 	]
 }

--- a/catch/hipTestMain/config/config_amd_windows_common.json
+++ b/catch/hipTestMain/config/config_amd_windows_common.json
@@ -98,6 +98,6 @@
 	   "Unit_hipGraphDestroyNode_Complx_ChkNumOfNodesNDep_ClonedGrph",
 	   "Unit_hipGraphDestroyNode_Complx_ChkNumOfNodesNDep_ChldNode",
 	   "Unit_hipMemGetAddressRange_Negative",
-       "Unit_hipMemGetAddressRange_Positive"
+	   "Unit_hipMemGetAddressRange_Positive"
 	]
 }

--- a/catch/hipTestMain/config/config_amd_windows_common.json
+++ b/catch/hipTestMain/config/config_amd_windows_common.json
@@ -97,6 +97,7 @@
 	   "Unit_hipGraphDestroyNode_Complx_ChkNumOfNodesNDep",
 	   "Unit_hipGraphDestroyNode_Complx_ChkNumOfNodesNDep_ClonedGrph",
 	   "Unit_hipGraphDestroyNode_Complx_ChkNumOfNodesNDep_ChldNode",
-	   "Unit_hipMemGetAddressRange_Negative"
+	   "Unit_hipMemGetAddressRange_Negative",
+       "Unit_hipMemGetAddressRange_Positive"
 	]
 }


### PR DESCRIPTION
Disabled the following tests on Linux:
- Unit_hipMemRangeGetAttribute_Positive_AccessedBy_Basic
- Unit_hipMemRangeGetAttribute_Positive_AccessedBy_Partial_Range
- Unit_hipMemRangeGetAttributes_Negative_Parameters
- Unit_hipStreamAttachMemAsync_Positive_Basic
- Unit_hipStreamAttachMemAsync_Positive_AttachGlobal
- Unit_hipStreamAttachMemAsync_Negative_Parameters
- Unit_hipMemGetAddressRange_Positive
Disabled the following tests on Windows:
- Unit_hipMemGetAddressRange_Positive