### PR TITLE
SWDEV-327563 - Disable Unit_hipGraphRetainUserObject_Functional_2 test.

### DIFF
--- a/catch/hipTestMain/config/config_amd_linux_common.json
+++ b/catch/hipTestMain/config/config_amd_linux_common.json
@@ -27,6 +27,8 @@
 	   "Unit_hipStreamAttachMemAsync_Negative_Parameters",
 	   "Unit_hipMemGetAddressRange_Positive",
 	   "Unit_hipGraphAddMemcpyNode1D_Negative_Basic",
-	   "Unit_hipStreamGetCaptureInfo_Nullstream_CaptureInfo"
+	   "Unit_hipStreamGetCaptureInfo_Nullstream_CaptureInfo",
+	   "intermittent issue: corrupted double-linked list",
+	   "Unit_hipGraphRetainUserObject_Functional_2"
 	]
 }


### PR DESCRIPTION
SWDEV-327563 - Disable Unit_hipGraphRetainUserObject_Functional_2 test.

Intermittent issue: corrupted doubly linked list