### PR TITLE
Disable Unit_hipGraphRetainUserObject_Functional_2

### DIFF
--- a/catch/hipTestMain/config/config_amd_windows_common.json
+++ b/catch/hipTestMain/config/config_amd_windows_common.json
@@ -100,6 +100,8 @@
 	   "Unit_hipGraphDestroyNode_Complx_ChkNumOfNodesNDep_ClonedGrph",
 	   "Unit_hipGraphDestroyNode_Complx_ChkNumOfNodesNDep_ChldNode",
 	   "Unit_hipMemGetAddressRange_Negative",
-	   "Unit_hipMemGetAddressRange_Positive"
+	   "Unit_hipMemGetAddressRange_Positive",
+	   "Note: intermittent Failure",
+	   "Unit_hipGraphRetainUserObject_Functional_2"
 	]
 }


### PR DESCRIPTION
On Windows due to intermittent failures.