### PR TITLE
SWDEV-326798 - Disabling tests to allow hipamd PR 819248

### DIFF
--- a/catch/hipTestMain/config/config_amd_linux_common.json
+++ b/catch/hipTestMain/config/config_amd_linux_common.json
@@ -49,6 +49,7 @@
 	   "Unit_hipStreamSetCaptureDependencies_Positive_Functional",
 	   "Note: Test disabled due to defect - EXSWHTEC-207",
 	   "Unit_hipGraphExecMemsetNodeSetParams_Negative_Updating_Non1D_Node",
-	   "Unit_hipIpcGetMemHandle_Positive_Unique_Handles_Separate_Allocations"
+	   "Unit_hipIpcGetMemHandle_Positive_Unique_Handles_Separate_Allocations",
+	   "Unit_hipStreamCreateWithFlags_DefaultStreamInteraction"
 	]
 }


### PR DESCRIPTION
SWDEV-326798 - Disabling tests to allow hipamd PR 819248 to be merged to interrupt dependency between hip-test and hipamd changes