### PR TITLE
SWDEV-395683 - skipping Unit_hipStreamPerThread_MultiThread

### DIFF
--- a/catch/hipTestMain/config/config_amd_linux_common.json
+++ b/catch/hipTestMain/config/config_amd_linux_common.json
@@ -60,6 +60,8 @@
 	   "Unit_hipMemset3DSync",
 	   "Unit_hipStreamAddCallback_StrmSyncTiming",
 	   "Disabling test tracked SWDEV-394199",
-	   "Unit_hipStreamCreateWithPriority_MulthreadNonblockingflag"
+	   "Unit_hipStreamCreateWithPriority_MulthreadNonblockingflag",
+	   "Disabling test tracked SWDEV-395683",
+	   "Unit_hipStreamPerThread_MultiThread"
 	]
 }


### PR DESCRIPTION
SWDEV-395683 - skipping Unit_hipStreamPerThread_MultiThread 