### PR TITLE
SWDEV-396615 - skip multiple tests on Windows

### DIFF
--- a/catch/hipTestMain/config/config_amd_windows_common.json
+++ b/catch/hipTestMain/config/config_amd_windows_common.json
@@ -149,6 +149,14 @@
 	   "Unit_hipDeviceSetSharedMemConfig_Negative_Parameters",
 	   "Unit_hipDeviceGetUuid_Positive",
 	   "Disabling test tracked SWDEV-394199",
-	   "Unit_hipStreamCreateWithPriority_MulthreadNonblockingflag"
+	   "Unit_hipStreamCreateWithPriority_MulthreadNonblockingflag",
+	   "SWDEV-396618 hipEventElapsedTime returns sucess",
+	   "Unit_hipEventElapsedTime_NotReady_Negative",
+	   "SWDEV-396617 ExecMemcpyNodeSetParamsFromSymbol fails in direction",
+	   "Unit_hipGraphExecMemcpyNodeSetParamsFromSymbol_Negative_Parameters",
+	   "SWDEV-396616 hipMemMap returns invalid error",
+	   "Unit_hipMemVmm_Basic",
+	   "SWDEV-396615 mGPUs not considered correctly",
+	   "Unit_hipManagedKeyword_MultiGpu"
 	]
 }


### PR DESCRIPTION
SWDEV-396615 - skip multiple tests on Windows

Unit_hipEventElapsedTime_NotReady_Negative
Unit_hipGraphExecMemcpyNodeSetParamsFromSymbol_Negative_Parameters Unit_hipMemVmm_Basic
Unit_hipManagedKeyword_MultiGpu