### PR TITLE
SWDEV-398977 - disable Unit_hipMemset2DSync

### DIFF
--- a/catch/hipTestMain/config/config_amd_linux_common.json
+++ b/catch/hipTestMain/config/config_amd_linux_common.json
@@ -69,7 +69,9 @@
 	   "Unit_hipMemcpyPeer_Positive_ZeroSize",
 	   "Unit_hipMemcpyPeerAsync_Positive_ZeroSize",
 	   "Disabling test tracked SWDEV-391718",
-	   "Unit_hipMemRangeGetAttribute_TstCountParam"
+	   "Unit_hipMemRangeGetAttribute_TstCountParam",
+	   "SWDEV-398977 fails in stress tests",
+	   "Unit_hipMemset2DSync"
 	]
 
 }


### PR DESCRIPTION
SWDEV-398977 - disable Unit_hipMemset2DSync
Unit_hipMemset2DSync fails in stress testing