### PR TITLE
SWDEV 409754: Disable sections of memcpy3D tests that cause llvm errors.

### DIFF
--- a/catch/unit/memory/hipMemcpy3D.cc
+++ b/catch/unit/memory/hipMemcpy3D.cc
@@ -31,7 +31,7 @@ THE SOFTWARE.
 TEST_CASE("Unit_hipMemcpy3D_Positive_Basic") {
   constexpr bool async = false;
 
-  SECTION("Device to Host") { Memcpy3DDeviceToHostShell<async>(Memcpy3DWrapper<>); }
+  //SWDEV-409754 SECTION("Device to Host") { Memcpy3DDeviceToHostShell<async>(Memcpy3DWrapper<>); }
 
   SECTION("Device to Device") {
     SECTION("Peer access disabled") {
@@ -40,9 +40,9 @@ TEST_CASE("Unit_hipMemcpy3D_Positive_Basic") {
     SECTION("Peer access enabled") { Memcpy3DDeviceToDeviceShell<async, true>(Memcpy3DWrapper<>); }
   }
 
-  SECTION("Host to Device") { Memcpy3DHostToDeviceShell<async>(Memcpy3DWrapper<>); }
+  //SWDEV-409754 SECTION("Host to Device") { Memcpy3DHostToDeviceShell<async>(Memcpy3DWrapper<>); }
 
-  SECTION("Host to Host") { Memcpy3DHostToHostShell<async>(Memcpy3DWrapper<>); }
+  //SWDEV-409754 SECTION("Host to Host") { Memcpy3DHostToHostShell<async>(Memcpy3DWrapper<>); }
 }
 
 TEST_CASE("Unit_hipMemcpy3D_Positive_Synchronization_Behavior") {
@@ -74,7 +74,7 @@ TEST_CASE("Unit_hipMemcpy3D_Positive_Parameters") {
 
 TEST_CASE("Unit_hipMemcpy3D_Positive_Array") {
   constexpr bool async = false;
-  SECTION("Array from/to Host") { Memcpy3DArrayHostShell<async>(Memcpy3DWrapper<async>); }
+  //SWDEV-409754 SECTION("Array from/to Host") { Memcpy3DArrayHostShell<async>(Memcpy3DWrapper<async>); }
 #if HT_NVIDIA  // Disabled on AMD due to defect - EXSWHTEC-238
   SECTION("Array from/to Device") { Memcpy3DArrayDeviceShell<async>(Memcpy3DWrapper<async>); }
 #endif

--- a/catch/unit/memory/hipMemcpy3DAsync.cc
+++ b/catch/unit/memory/hipMemcpy3DAsync.cc
@@ -35,7 +35,7 @@ TEST_CASE("Unit_hipMemcpy3DAsync_Positive_Basic") {
   const StreamGuard stream_guard(stream_type);
   const hipStream_t stream = stream_guard.stream();
 
-  SECTION("Device to Host") { Memcpy3DDeviceToHostShell<async>(Memcpy3DWrapper<async>, stream); }
+  //SECTION("Device to Host") { Memcpy3DDeviceToHostShell<async>(Memcpy3DWrapper<async>, stream); }
 
   SECTION("Device to Device") {
     SECTION("Peer access disabled") {
@@ -46,9 +46,9 @@ TEST_CASE("Unit_hipMemcpy3DAsync_Positive_Basic") {
     }
   }
 
-  SECTION("Host to Device") { Memcpy3DHostToDeviceShell<async>(Memcpy3DWrapper<async>, stream); }
+  //SECTION("Host to Device") { Memcpy3DHostToDeviceShell<async>(Memcpy3DWrapper<async>, stream); }
 
-  SECTION("Host to Host") { Memcpy3DHostToHostShell<async>(Memcpy3DWrapper<async>, stream); }
+  //SECTION("Host to Host") { Memcpy3DHostToHostShell<async>(Memcpy3DWrapper<async>, stream); }
 }
 
 TEST_CASE("Unit_hipMemcpy3DAsync_Positive_Synchronization_Behavior") {
@@ -82,7 +82,7 @@ TEST_CASE("Unit_hipMemcpy3DAsync_Positive_Parameters") {
 
 TEST_CASE("Unit_hipMemcpy3DAsync_Positive_Array") {
   constexpr bool async = true;
-  SECTION("Array from/to Host") { Memcpy3DArrayHostShell<async>(Memcpy3DWrapper<async>); }
+  //SECTION("Array from/to Host") { Memcpy3DArrayHostShell<async>(Memcpy3DWrapper<async>); }
 #if HT_NVIDIA // Disabled on AMD due to defect - EXSWHTEC-238
   SECTION("Array from/to Device") { Memcpy3DArrayDeviceShell<async>(Memcpy3DWrapper<async>); }
 #endif

--- a/catch/unit/memory/hipMemcpy3DAsync.cc
+++ b/catch/unit/memory/hipMemcpy3DAsync.cc
@@ -35,7 +35,7 @@ TEST_CASE("Unit_hipMemcpy3DAsync_Positive_Basic") {
   const StreamGuard stream_guard(stream_type);
   const hipStream_t stream = stream_guard.stream();
 
-  //SECTION("Device to Host") { Memcpy3DDeviceToHostShell<async>(Memcpy3DWrapper<async>, stream); }
+  SECTION("Device to Host") { Memcpy3DDeviceToHostShell<async>(Memcpy3DWrapper<async>, stream); }
 
   SECTION("Device to Device") {
     SECTION("Peer access disabled") {
@@ -46,9 +46,9 @@ TEST_CASE("Unit_hipMemcpy3DAsync_Positive_Basic") {
     }
   }
 
-  //SECTION("Host to Device") { Memcpy3DHostToDeviceShell<async>(Memcpy3DWrapper<async>, stream); }
+  SECTION("Host to Device") { Memcpy3DHostToDeviceShell<async>(Memcpy3DWrapper<async>, stream); }
 
-  //SECTION("Host to Host") { Memcpy3DHostToHostShell<async>(Memcpy3DWrapper<async>, stream); }
+  //SWDEV-409754 SECTION("Host to Host") { Memcpy3DHostToHostShell<async>(Memcpy3DWrapper<async>, stream); }
 }
 
 TEST_CASE("Unit_hipMemcpy3DAsync_Positive_Synchronization_Behavior") {
@@ -82,7 +82,7 @@ TEST_CASE("Unit_hipMemcpy3DAsync_Positive_Parameters") {
 
 TEST_CASE("Unit_hipMemcpy3DAsync_Positive_Array") {
   constexpr bool async = true;
-  //SECTION("Array from/to Host") { Memcpy3DArrayHostShell<async>(Memcpy3DWrapper<async>); }
+  //SWDEV-409754 SECTION("Array from/to Host") { Memcpy3DArrayHostShell<async>(Memcpy3DWrapper<async>); }
 #if HT_NVIDIA // Disabled on AMD due to defect - EXSWHTEC-238
   SECTION("Array from/to Device") { Memcpy3DArrayDeviceShell<async>(Memcpy3DWrapper<async>); }
 #endif


### PR DESCRIPTION
Temporarily disable sections of the test that cause assertion errors when compiling with specific patch of llvm. 