### PR TITLE
SWDEV-395996 - Disable hiprtc tests temporarily

### DIFF
--- a/catch/hipTestMain/config/config_amd_linux_MI2xx.json
+++ b/catch/hipTestMain/config/config_amd_linux_MI2xx.json
@@ -17,7 +17,17 @@
 		"Unit_hipSignalExternalSemaphoresAsync_Vulkan_Negative_Parameters",
 		"Unit_hipImportExternalSemaphore_Vulkan_Negative_Parameters",
 		"Unit_hipDestroyExternalSemaphore_Vulkan_Negative_Parameters",
-		"Unit_Grid_Group_Sync_Positive_Basic"
+		"Unit_Grid_Group_Sync_Positive_Basic",
+                "=== Below hiprtc tests are disabled temporarily,  will be renabled once patches for SWDEV-395996 are merged ===",
+                "Unit_hiprtc_saxpy.Unit_hiprtc_saxpy",
+                "Unit_hiprtc_warpsize.Unit_hiprtc_warpsize",
+                "Unit_hiprtc_functional.Unit_hiprtc_functional",
+                "Unit_hipStreamCaptureRtc.Unit_hipStreamCaptureRtc",
+                "Unit_hiprtc_cpp17.Unit_hiprtc_cpp17",
+                "Unit_hiprtc_namehandling.Unit_hiprtc_namehandling",
+                "Unit_hiprtc_getloweredname.Unit_hiprtc_getloweredname",
+                "Unit_hiprtc_test_hip_bfloat16.Unit_hiprtc_test_hip_bfloat16",
+                "Unit_RTC_LinkerAPI.Unit_RTC_LinkerAPI"
 	]
 
 }

--- a/catch/hipTestMain/config/config_amd_linux_common.json
+++ b/catch/hipTestMain/config/config_amd_linux_common.json
@@ -113,6 +113,17 @@
 	   "Unit_hipStreamValue_Wait32_Blocking_Mask_Eq_1",
 	   "=== Below tests fail in stress test on 24/07/23 ===",
 	   "Unit_hipStreamCreateWithPriority_ValidateWithEvents",
-	   "Unit_hipEventIpc"
+	   "Unit_hipEventIpc",
+           "=== Below hiprtc tests are disabled temporarily,  will be renabled once patches for SWDEV-395996 are merged ===",
+           "Unit_hiprtc_saxpy.Unit_hiprtc_saxpy",
+           "Unit_hiprtc_warpsize.Unit_hiprtc_warpsize",
+           "Unit_hiprtc_functional.Unit_hiprtc_functional",
+           "Unit_hipStreamCaptureRtc.Unit_hipStreamCaptureRtc",
+           "Unit_hiprtc_cpp17.Unit_hiprtc_cpp17",
+           "Unit_hiprtc_namehandling.Unit_hiprtc_namehandling",
+           "Unit_hiprtc_getloweredname.Unit_hiprtc_getloweredname",
+           "Unit_hiprtc_test_hip_bfloat16.Unit_hiprtc_test_hip_bfloat16",
+           "Unit_RTC_LinkerAPI.Unit_RTC_LinkerAPI"
+
 	]
 }

--- a/catch/hipTestMain/config/config_amd_windows_MI2xx.json
+++ b/catch/hipTestMain/config/config_amd_windows_MI2xx.json
@@ -93,10 +93,20 @@
 		"Unit_hipInit_Negative",
 		"Unit_hipGraphAddEventRecordNode_Functional_ElapsedTime",
 		"Unit_hipStreamBeginCapture_captureComplexGraph",
-		"Unit_hipGraphAddChildGraphNode_MultGraphsAsSingleGraph"
-		"Unit_hipMemGetAddressRange_Negative",
+		"Unit_hipGraphAddChildGraphNode_MultGraphsAsSingleGraph",
+                "Unit_hipMemGetAddressRange_Negative",
 		"Unit_hipStreamValue_Wait64_Blocking_NoMask_Nor",
 		"Unit_hipLaunchHostFunc_Graph",
-		"Unit_hipLaunchHostFunc_KernelHost"
+		"Unit_hipLaunchHostFunc_KernelHost",
+                "=== Below hiprtc tests are disabled temporarily,  will be renabled once patches for SWDEV-395996 are merged ===",
+                "Unit_hiprtc_saxpy.Unit_hiprtc_saxpy",
+                "Unit_hiprtc_warpsize.Unit_hiprtc_warpsize",
+                "Unit_hiprtc_functional.Unit_hiprtc_functional",
+                "Unit_hipStreamCaptureRtc.Unit_hipStreamCaptureRtc",
+                "Unit_hiprtc_cpp17.Unit_hiprtc_cpp17",
+                "Unit_hiprtc_namehandling.Unit_hiprtc_namehandling",
+                "Unit_hiprtc_getloweredname.Unit_hiprtc_getloweredname",
+                "Unit_hiprtc_test_hip_bfloat16.Unit_hiprtc_test_hip_bfloat16",
+                "Unit_RTC_LinkerAPI.Unit_RTC_LinkerAPI"
 	]
 }

--- a/catch/hipTestMain/config/config_amd_windows_common.json
+++ b/catch/hipTestMain/config/config_amd_windows_common.json
@@ -211,6 +211,16 @@
 	   "Unit_hipMemcpyAsync_Negative_Parameters",
 	   "Unit_hipMemcpyDtoHAsync_Negative_Parameters",
 	   "Unit_hipMemcpyHtoDAsync_Negative_Parameters",
-	   "Unit_hipMemcpyDtoDAsync_Negative_Parameters"
+	   "Unit_hipMemcpyDtoDAsync_Negative_Parameters",
+           "=== Below hiprtc tests are disabled temporarily,  will be renabled once patches for SWDEV-395996 are merged ===",
+           "Unit_hiprtc_saxpy.Unit_hiprtc_saxpy",
+           "Unit_hiprtc_warpsize.Unit_hiprtc_warpsize",
+           "Unit_hiprtc_functional.Unit_hiprtc_functional",
+           "Unit_hipStreamCaptureRtc.Unit_hipStreamCaptureRtc",
+           "Unit_hiprtc_cpp17.Unit_hiprtc_cpp17",
+           "Unit_hiprtc_namehandling.Unit_hiprtc_namehandling",
+           "Unit_hiprtc_getloweredname.Unit_hiprtc_getloweredname",
+           "Unit_hiprtc_test_hip_bfloat16.Unit_hiprtc_test_hip_bfloat16",
+           "Unit_RTC_LinkerAPI.Unit_RTC_LinkerAPI"
 	]
 }


### PR DESCRIPTION
Disabling the hiprtc tests temporarily as there are 2 dependent patches in hip and clr repos for supporting all the hip headers with hiprtc.  will enable these tests back as soon as the 2 patches are merged