### PR TITLE
[DO NOT MERGE] Revert "SWDEV-385161 - Deprecate usage of env vars in HIP samples and tests"

### DIFF
--- a/catch/CMakeLists.txt
+++ b/catch/CMakeLists.txt
@@ -9,45 +9,51 @@ project(hiptests)
 # flag to generate standalone exe per src file.
 message(STATUS "STANDALONE_TESTS : ${STANDALONE_TESTS}")
 
-# Check if platform is set
-if(NOT HIP_PLATFORM STREQUAL "amd" AND NOT HIP_PLATFORM STREQUAL "nvidia")
+# Check if platform and compiler are set
+if(HIP_PLATFORM STREQUAL "amd")
+    if(HIP_COMPILER STREQUAL "nvcc")
+        message(FATAL_ERROR "Unexpected HIP_COMPILER:${HIP_COMPILER} is set for HIP_PLATFOR:amd")
+    endif()
+elseif(HIP_PLATFORM STREQUAL "nvidia")
+    if(DEFINED HIP_COMPILER AND NOT HIP_COMPILER STREQUAL "nvcc")
+        message(FATAL_ERROR "Unexpected HIP_COMPILER: ${HIP_COMPILER} is set for HIP_PLATFORM:nvidia")
+    endif()
+else()
     message(FATAL_ERROR "Unexpected HIP_PLATFORM: " ${HIP_PLATFORM})
 endif()
 
-if(WIN32)
+if (WIN32)
     set(EXT ".bat")
 endif()
 
-if(HIP_PLATFORM STREQUAL "amd")
-   if(UNIX AND DEFINED ROCM_PATH)
-      # Read -DROCM_PATH and set CXX_FLAGS for amd platform only
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --rocm-path=${ROCM_PATH}")
-   endif()
-
-   if(DEFINED HIP_PATH)
-      # Read -DHIP_PATH and set CXX_FLAGS for amd platform only
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --hip-path=${HIP_PATH}")
-   endif()
-endif()
-
-# Read -DHIP_PATH
-# If not set read env{HIP_PATH} only on Windows
-if(WIN32)
-    if(NOT DEFINED HIP_PATH)
-        if(DEFINED ENV{HIP_PATH})
-            set(HIP_PATH $ENV{HIP_PATH} CACHE STRING "HIP Path")
-        endif()
+# Read -DROCM_Path and env{ROCM_PATH}
+if(NOT DEFINED ROCM_PATH)
+    if(DEFINED ENV{ROCM_PATH})
+        set(ROCM_PATH $ENV{ROCM_PATH} CACHE STRING "ROCM Path")
     endif()
 endif()
 
+# Read -DHIP_Path and env{HIP_PATH}
 if(NOT DEFINED HIP_PATH)
-   if(DEFINED ROCM_PATH)
-      set(HIP_PATH ${ROCM_PATH})
-   else()
-      set(HIP_PATH "/opt/rocm")
-   endif()
+    if(DEFINED ENV{HIP_PATH})
+        set(HIP_PATH $ENV{HIP_PATH} CACHE STRING "HIP Path")
+    endif()
+endif()
+
+# both are not set
+if(NOT DEFINED HIP_PATH AND NOT DEFINED ROCM_PATH)
+    set(HIP_PATH "/opt/rocm")
+    set(ROCM_PATH "/opt/rocm")
+elseif(DEFINED HIP_PATH AND NOT DEFINED ROCM_PATH)
+    execute_process(COMMAND ${HIP_PATH}/bin/hipconfig${EXT} --rocmpath
+                OUTPUT_VARIABLE ROCM_PATH
+                OUTPUT_STRIP_TRAILING_WHITESPACE)
+elseif(DEFINED ROCM_PATH AND NOT DEFINED HIP_PATH)
+    set(HIP_PATH ${ROCM_PATH})
 endif()
 message(STATUS "HIP_PATH: ${HIP_PATH}")
+message(STATUS "ROCM_PATH: ${ROCM_PATH}")
+
 
 set(CMAKE_CXX_COMPILER "${HIP_PATH}/bin/hipcc${EXT}")
 set(CMAKE_C_COMPILER "${HIP_PATH}/bin/hipcc${EXT}")
@@ -56,6 +62,10 @@ execute_process(COMMAND ${HIPCONFIG_EXECUTABLE} --version
                 OUTPUT_VARIABLE HIP_VERSION
                 OUTPUT_STRIP_TRAILING_WHITESPACE)
 
+if(HIP_PLATFORM STREQUAL "amd")
+    # prioritize -DROCM_PATH over env{ROCM_PATH} for amd platform only
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --rocm-path=${ROCM_PATH}")
+endif()
 # enforce c++17
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --std=c++17")
 
@@ -145,8 +155,8 @@ if (WIN32)
   SET(CMAKE_CXX_RESPONSE_FILE_LINK_FLAG "")
 endif()
 
-if(HIP_PLATFORM STREQUAL "amd")
-    add_compile_options(-Wall -Wextra -Werror -Wno-deprecated)
+if(HIP_PLATFORM MATCHES "amd" AND HIP_COMPILER MATCHES "clang")
+    add_compile_options(-Wall -Wextra -pedantic -Werror -Wno-deprecated)
 endif()
 
 cmake_policy(PUSH)
@@ -168,8 +178,10 @@ message(STATUS "CMAKE HIP ARCHITECTURES: ${CMAKE_HIP_ARCHITECTURES}")
 # That results in hipcc building the test for gfx803 (the default target)
 # preference to pass arch -
 # OFFLOAD_ARCH_STR
+# ENV{HCC_AMDGPU_TARGET}
 # rocm_agent_enumerator
 if(NOT DEFINED OFFLOAD_ARCH_STR
+   AND NOT DEFINED ENV{HCC_AMDGPU_TARGET}
    AND EXISTS "${ROCM_PATH}/bin/rocm_agent_enumerator"
    AND HIP_PLATFORM STREQUAL "amd" AND UNIX)
     execute_process(COMMAND ${ROCM_PATH}/bin/rocm_agent_enumerator
@@ -196,6 +208,10 @@ endif()
 
 if(DEFINED OFFLOAD_ARCH_STR)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OFFLOAD_ARCH_STR} ")
+elseif(DEFINED ENV{HCC_AMDGPU_TARGET})
+    # hipcc pl script appends it to the options
+    set(OFFLOAD_ARCH_STR "--offload-arch=$ENV{HCC_AMDGPU_TARGET}")
+    set(HIP_GPU_ARCH_LIST $ENV{HCC_AMDGPU_TARGET})
 endif()
 message(STATUS "Using offload arch string: ${OFFLOAD_ARCH_STR}")
 
@@ -224,7 +240,7 @@ set(_subdirs ${_autogen} "subdirs(..)\n")
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${CATCH_BUILD_DIR}/CTestTestfile.cmake ${_subdirs})
 
 # Enable device lambda on nvidia platforms
-if(HIP_PLATFORM STREQUAL "nvidia")
+if(HIP_COMPILER MATCHES "nvcc")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --extended-lambda")
 endif()
 

--- a/catch/README.md
+++ b/catch/README.md
@@ -11,7 +11,7 @@ Tests in Catch2 are declared via ```TEST_CASE```.
 [Catch2 Detailed Reference](https://github.com/catchorg/Catch2/blob/v2.13.6/docs/Readme.md#top)
 
 ## Taking care of existing features
-- Don’t build on platform: EXCLUDE_HIP_PLATFORM, can be done via CMAKE. Adding source in if(HIP_PLATFORM == amd/nvidia).
+- Don’t build on platform: EXCLUDE_(HIP_PLATFORM/HIP_RUNTIME), can be done via CMAKE. Adding source in if(HIP_PLATFORM == amd/nvidia).
 - HIPCC_OPTIONS/CLANG Options: Can be done via: set_source_files_properties(src.cc PROPERTIES COMPILE_FLAGS “…”).
 - Additional libraries: Can be done via target_link_libraries()
 - Multiple runs with different args: This can be done by Catch’s Feature: GENERATE(…)

--- a/catch/include/hip_test_common.hh
+++ b/catch/include/hip_test_common.hh
@@ -21,7 +21,6 @@ THE SOFTWARE.
 */
 
 #pragma once
-#pragma clang diagnostic ignored "-Wsign-compare"
 #include "hip_test_context.hh"
 
 #include <catch.hpp>
@@ -356,7 +355,7 @@ class BlockingContext {
   hipStream_t stream;
 
  public:
-  BlockingContext(hipStream_t s) : blocked(true), stream(s) {}
+  BlockingContext(hipStream_t s) : stream(s), blocked(true) {}
 
   BlockingContext(const BlockingContext& in) {
     blocked = in.blocked_val();

--- a/catch/include/memcpy3d_tests_common.hh
+++ b/catch/include/memcpy3d_tests_common.hh
@@ -21,8 +21,7 @@ THE SOFTWARE.
 */
 
 #pragma once
-#pragma clang diagnostic ignored "-Wmissing-field-initializers"
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
+
 #include <variant>
 
 #include <hip_test_common.hh>
@@ -32,7 +31,7 @@ THE SOFTWARE.
 
 using PtrVariant = std::variant<hipPitchedPtr, hipArray_t>;
 
-static inline hipMemcpyKind ReverseMemcpyDirection(const hipMemcpyKind direction) {
+static hipMemcpyKind ReverseMemcpyDirection(const hipMemcpyKind direction) {
   switch (direction) {
     case hipMemcpyHostToDevice:
       return hipMemcpyDeviceToHost;
@@ -77,7 +76,7 @@ static bool operator==(const hipExtent& lhs, const hipExtent& rhs) {
   return lhs.width == rhs.width && lhs.height == rhs.height && lhs.depth == rhs.depth;
 }
 
-static inline bool operator==(const hipMemcpy3DParms& lhs, const hipMemcpy3DParms& rhs) {
+static bool operator==(const hipMemcpy3DParms& lhs, const hipMemcpy3DParms& rhs) {
   return lhs.dstArray == rhs.dstArray && lhs.dstPtr == rhs.dstPtr && lhs.dstPos == rhs.dstPos &&
       lhs.srcArray == rhs.srcArray && lhs.srcPtr == rhs.srcPtr && lhs.srcPos == rhs.srcPos &&
       lhs.extent == rhs.extent && lhs.kind == rhs.kind;
@@ -169,6 +168,7 @@ void Memcpy3DDeviceToDeviceShell(F memcpy_func, const hipStream_t kernel_stream 
   const auto device_count = HipTest::getDeviceCount();
   const auto src_device = GENERATE_COPY(range(0, device_count));
   const auto dst_device = GENERATE_COPY(range(0, device_count));
+  const size_t src_cols_mult = GENERATE(1, 2);
 
   INFO("Src device: " << src_device << ", Dst device: " << dst_device);
 

--- a/catch/include/performance_common.hh
+++ b/catch/include/performance_common.hh
@@ -33,9 +33,6 @@ THE SOFTWARE.
 #include <hip_test_common.hh>
 #include <resource_guards.hh>
 
-#pragma clang diagnostic ignored "-Wunused-but-set-variable"
-#pragma clang diagnostic ignored "-Wunused-function"
-
 #if defined(_WIN32)
 #if defined(_WIN64)
 typedef __int64 ssize_t;

--- a/catch/multiproc/hipMemCoherencyTstMProc.cc
+++ b/catch/multiproc/hipMemCoherencyTstMProc.cc
@@ -131,6 +131,7 @@ TEST_CASE("Unit_malloc_CoherentTst") {
   p = strstr(prop.gcnArchName, "xnack+");
   if (p) {
     // Test Case execution begins from here
+    int stat = 0;
     int managed = 0;
     HIPCHECK(hipDeviceGetAttribute(&managed, hipDeviceAttributeManagedMemory,
                                     0));
@@ -161,6 +162,7 @@ TEST_CASE("Unit_malloc_CoherentTstWthAdvise") {
   char *p = NULL;
   p = strstr(prop.gcnArchName, "xnack+");
   if (p) {
+    int stat = 0;
     int managed = 0;
     HIP_CHECK(hipDeviceGetAttribute(&managed, hipDeviceAttributeManagedMemory,
                                     0));
@@ -193,6 +195,7 @@ TEST_CASE("Unit_mmap_CoherentTst") {
   char *p = NULL;
   p = strstr(prop.gcnArchName, "xnack+");
   if (p) {
+    int stat = 0;
     int managed = 0;
     HIP_CHECK(hipDeviceGetAttribute(&managed, hipDeviceAttributeManagedMemory,
                                     0));
@@ -230,6 +233,7 @@ TEST_CASE("Unit_mmap_CoherentTstWthAdvise") {
   char *p = NULL;
   p = strstr(prop.gcnArchName, "xnack+");
   if (p) {
+    int stat = 0;
     int managed = 0;
     HIP_CHECK(hipDeviceGetAttribute(&managed, hipDeviceAttributeManagedMemory,
                                     0));

--- a/catch/unit/cooperativeGrps/coalesced_groups_shfl_down.cc
+++ b/catch/unit/cooperativeGrps/coalesced_groups_shfl_down.cc
@@ -31,7 +31,7 @@ THE SOFTWARE.
 #include <hip/hip_cooperative_groups.h>
 #include <stdio.h>
 #include <vector>
-#pragma clang diagnostic ignored "-Wunused-variable"
+
 using namespace cooperative_groups;
 
 #define ASSERT_EQUAL(lhs, rhs) assert(lhs == rhs)

--- a/catch/unit/cooperativeGrps/coalesced_groups_shfl_up.cc
+++ b/catch/unit/cooperativeGrps/coalesced_groups_shfl_up.cc
@@ -30,7 +30,7 @@ THE SOFTWARE.
 #include <hip/hip_cooperative_groups.h>
 #include <stdio.h>
 #include <vector>
-#pragma clang diagnostic ignored "-Wunused-variable"
+
 using namespace cooperative_groups;
 
 #define ASSERT_EQUAL(lhs, rhs) assert(lhs == rhs)

--- a/catch/unit/cooperativeGrps/grid_group.cc
+++ b/catch/unit/cooperativeGrps/grid_group.cc
@@ -143,7 +143,7 @@ TEST_CASE("Unit_Grid_Group_Getters_Positive_Basic") {
   HIP_CHECK(hipDeviceSynchronize());
 
   // Verify grid_group.is_valid() values
-  ArrayAllOf(uint_arr.ptr(), grid.thread_count_, [](uint32_t) { return 1; });
+  ArrayAllOf(uint_arr.ptr(), grid.thread_count_, [](uint32_t i) { return 1; });
 }
 
 /**

--- a/catch/unit/device/getDeviceCount_exe.cc
+++ b/catch/unit/device/getDeviceCount_exe.cc
@@ -34,10 +34,10 @@ bool UNSETENV(std::string var) {
   return (result == 0) ? true: false;
 }
 
-bool SETENV(std::string var, std::string value) {
+bool SETENV(std::string var, std::string value, int overwrite) {
   int result = -1;
   #ifdef __unix__
-    result = setenv(var.c_str(), value.c_str(), 1);
+    result = setenv(var.c_str(), value.c_str(), overwrite);
   #else
     result = _putenv((var + '=' + value).c_str());
   #endif
@@ -59,7 +59,7 @@ int main(int argc, char** argv) {
   // disable visible_devices env from shell
 #ifdef __HIP_PLATFORM_NVCC__
   UNSETENV("CUDA_VISIBLE_DEVICES");
-  SETENV("CUDA_VISIBLE_DEVICES", argv[1]);
+  SETENV("CUDA_VISIBLE_DEVICES", argv[1], 1);
   auto init_res = hipInit(0);
   if (hipSuccess != init_res) {
     std::cerr << "CUDA INIT API returned : " << hipGetErrorString(init_res) << std::endl;
@@ -68,8 +68,8 @@ int main(int argc, char** argv) {
 #else
   UNSETENV("ROCR_VISIBLE_DEVICES");
   UNSETENV("HIP_VISIBLE_DEVICES");
-  SETENV("ROCR_VISIBLE_DEVICES", argv[1]);
-  SETENV("HIP_VISIBLE_DEVICES", argv[1]);
+  SETENV("ROCR_VISIBLE_DEVICES", argv[1], 1);
+  SETENV("HIP_VISIBLE_DEVICES", argv[1], 1);
 #endif
 
   int count = 0;

--- a/catch/unit/device/hipDeviceGetP2PAttribute_exe.cc
+++ b/catch/unit/device/hipDeviceGetP2PAttribute_exe.cc
@@ -32,10 +32,10 @@ bool UNSETENV(std::string var) {
   return (result == 0) ? true: false;
 }
 
-bool SETENV(std::string var, std::string value) {
+bool SETENV(std::string var, std::string value, int overwrite) {
   int result = -1;
   #ifdef __unix__
-    result = setenv(var.c_str(), value.c_str(), 1);
+    result = setenv(var.c_str(), value.c_str(), overwrite);
   #else
     result = _putenv((var + '=' + value).c_str());
   #endif
@@ -44,10 +44,10 @@ bool SETENV(std::string var, std::string value) {
 
 void inline hideDevices(const char* devices) {
 #if HT_NVIDIA
-  SETENV("CUDA_VISIBLE_DEVICES", devices);
+  SETENV("CUDA_VISIBLE_DEVICES", devices, 1);
 #else
-  SETENV("HIP_VISIBLE_DEVICES", devices);
-  SETENV("ROCR_VISIBLE_DEVICES", devices);
+  SETENV("HIP_VISIBLE_DEVICES", devices, 1);
+  SETENV("ROCR_VISIBLE_DEVICES", devices, 1);
 #endif
 }
 

--- a/catch/unit/device/hipDeviceGetUuid.cc
+++ b/catch/unit/device/hipDeviceGetUuid.cc
@@ -53,7 +53,7 @@ TEST_CASE("Unit_hipDeviceGetUuid_Positive") {
 
   // Atleast one non zero value
   size_t uuidSize = sizeof(uuid.bytes) / sizeof(uuid.bytes[0]);
-  for (size_t i = 0; i < uuidSize; i++) {
+  for (int i = 0; i < uuidSize; i++) {
     if (uuid.bytes[i] != 0) {
       uuidValid = true;
       break;

--- a/catch/unit/deviceLib/BuiltIns_fadd.cc
+++ b/catch/unit/deviceLib/BuiltIns_fadd.cc
@@ -198,8 +198,8 @@ TEST_CASE("Unit_BuiltInAtomicAdd_CoherentGlobalMemWithRtc") {
       void* config_d[] = {HIP_LAUNCH_PARAM_BUFFER_POINTER, &args_f,
                           HIP_LAUNCH_PARAM_BUFFER_SIZE,
                           &size, HIP_LAUNCH_PARAM_END};
-      HIP_CHECK(hipModuleLaunchKernel(fmaxkernel, 1, 1, 1, 1, 1, 1, 0,
-                            nullptr, nullptr, config_d));
+      hipModuleLaunchKernel(fmaxkernel, 1, 1, 1, 1, 1, 1, 0,
+                            nullptr, nullptr, config_d);
       HIP_CHECK(hipDeviceSynchronize());
       HIP_CHECK(hipMemcpy(B_h, result, sizeof(double), hipMemcpyDeviceToHost));
       REQUIRE(A_h[0] == INITIAL_VAL);
@@ -278,8 +278,8 @@ TEST_CASE("Unit_BuiltInAtomicAdd_NonCoherentGlobalMemWithRtc") {
       void* config_d[] = {HIP_LAUNCH_PARAM_BUFFER_POINTER, &args_f,
                           HIP_LAUNCH_PARAM_BUFFER_SIZE,
                           &size, HIP_LAUNCH_PARAM_END};
-      HIP_CHECK(hipModuleLaunchKernel(fmaxkernel, 1, 1, 1, 1, 1, 1, 0,
-                            nullptr, nullptr, config_d));
+      hipModuleLaunchKernel(fmaxkernel, 1, 1, 1, 1, 1, 1, 0,
+                            nullptr, nullptr, config_d);
       HIP_CHECK(hipDeviceSynchronize());
       HIP_CHECK(hipMemcpy(B_h, result, sizeof(double), hipMemcpyDeviceToHost));
       REQUIRE(A_h[0] == INITIAL_VAL + INC_VAL);

--- a/catch/unit/deviceLib/BuiltIns_fmax.cc
+++ b/catch/unit/deviceLib/BuiltIns_fmax.cc
@@ -229,8 +229,8 @@ TEST_CASE("Unit_BuiltinAtomicsRTC_fmaxCoherentGlobalMem") {
       void* config_d[] = {HIP_LAUNCH_PARAM_BUFFER_POINTER, &args_f,
         HIP_LAUNCH_PARAM_BUFFER_SIZE,
         &size, HIP_LAUNCH_PARAM_END};
-      HIP_CHECK(hipModuleLaunchKernel(fmaxkernel, 1, 1, 1, 1, 1, 1, 0,
-                nullptr, nullptr, config_d));
+      hipModuleLaunchKernel(fmaxkernel, 1, 1, 1, 1, 1, 1, 0,
+          nullptr, nullptr, config_d);
       HIP_CHECK(hipDeviceSynchronize());
       HIP_CHECK(hipMemcpy(B_h, result, sizeof(double), hipMemcpyDeviceToHost));
       REQUIRE(*B_h == 0);
@@ -324,8 +324,8 @@ TEST_CASE("Unit_BuiltinAtomicsRTC_fmaxNonCoherentGlobalFlatMem") {
       void* config_d[] = {HIP_LAUNCH_PARAM_BUFFER_POINTER, &args_f,
         HIP_LAUNCH_PARAM_BUFFER_SIZE,
         &size, HIP_LAUNCH_PARAM_END};
-      HIP_CHECK(hipModuleLaunchKernel(fmaxkernel, 1, 1, 1, 1, 1, 1, 0,
-                nullptr, nullptr, config_d));
+      hipModuleLaunchKernel(fmaxkernel, 1, 1, 1, 1, 1, 1, 0,
+          nullptr, nullptr, config_d);
       HIP_CHECK(hipDeviceSynchronize());
       HIP_CHECK(hipMemcpy(B_h, result, sizeof(double), hipMemcpyDeviceToHost));
       REQUIRE(*B_h == INITIAL_VAL);

--- a/catch/unit/deviceLib/BuiltIns_fmin.cc
+++ b/catch/unit/deviceLib/BuiltIns_fmin.cc
@@ -230,8 +230,8 @@ TEST_CASE("Unit_BuiltinAtomicsRTC__fminCoherentGlobalMem") {
       void* config_d[] = {HIP_LAUNCH_PARAM_BUFFER_POINTER, &args_f,
         HIP_LAUNCH_PARAM_BUFFER_SIZE,
         &size, HIP_LAUNCH_PARAM_END};
-      HIP_CHECK(hipModuleLaunchKernel(fmaxkernel, 1, 1, 1, 1, 1, 1, 0,
-                nullptr, nullptr, config_d));
+      hipModuleLaunchKernel(fmaxkernel, 1, 1, 1, 1, 1, 1, 0,
+          nullptr, nullptr, config_d);
       HIP_CHECK(hipDeviceSynchronize());
       HIP_CHECK(hipMemcpy(B_h, result, sizeof(double), hipMemcpyDeviceToHost));
       REQUIRE(*B_h == 0);
@@ -327,8 +327,8 @@ TEST_CASE("Unit_BuiltinAtomicsRTC_fminNonCoherentGlobalFlatMem") {
       void* config_d[] = {HIP_LAUNCH_PARAM_BUFFER_POINTER, &args_f,
         HIP_LAUNCH_PARAM_BUFFER_SIZE,
         &size, HIP_LAUNCH_PARAM_END};
-      HIP_CHECK(hipModuleLaunchKernel(fmaxkernel, 1, 1, 1, 1, 1, 1, 0,
-                nullptr, nullptr, config_d));
+      hipModuleLaunchKernel(fmaxkernel, 1, 1, 1, 1, 1, 1, 0,
+          nullptr, nullptr, config_d);
       HIP_CHECK(hipDeviceSynchronize());
       HIP_CHECK(hipMemcpy(B_h, result, sizeof(double), hipMemcpyDeviceToHost));
       REQUIRE(*B_h == INITIAL_VAL);

--- a/catch/unit/deviceLib/hipStdComplex.cc
+++ b/catch/unit/deviceLib/hipStdComplex.cc
@@ -22,7 +22,6 @@ THE SOFTWARE.
 #include <hip_test_checkers.hh>
 #include <complex>
 
-#pragma clang diagnostic ignored "-Wunused-variable"
 // Tolerance for error
 const double tolerance = 1e-6;
 

--- a/catch/unit/deviceLib/unsafeAtomicAdd_RTC.cc
+++ b/catch/unit/deviceLib/unsafeAtomicAdd_RTC.cc
@@ -126,8 +126,8 @@ TEMPLATE_TEST_CASE("Unit_unsafeAtomicAdd_CoherentRTCnounsafeatomicflag", "",
       void* config_d[] = {HIP_LAUNCH_PARAM_BUFFER_POINTER, &args_f,
         HIP_LAUNCH_PARAM_BUFFER_SIZE,
         &size, HIP_LAUNCH_PARAM_END};
-      HIP_CHECK(hipModuleLaunchKernel(f_kernel, 1, 1, 1, 1, 1, 1, 0,
-                nullptr, nullptr, config_d));
+      hipModuleLaunchKernel(f_kernel, 1, 1, 1, 1, 1, 1, 0,
+          nullptr, nullptr, config_d);
       HIP_CHECK(hipDeviceSynchronize());
       REQUIRE(A_h[0] == INITIAL_VAL);
       REQUIRE(*result == 0);
@@ -218,8 +218,8 @@ TEMPLATE_TEST_CASE("Unit_unsafeAtomicAdd_CoherentRTCunsafeatomicflag", "",
       void* config_d[] = {HIP_LAUNCH_PARAM_BUFFER_POINTER, &args_f,
         HIP_LAUNCH_PARAM_BUFFER_SIZE,
         &size, HIP_LAUNCH_PARAM_END};
-      HIP_CHECK(hipModuleLaunchKernel(f_kernel, 1, 1, 1, 1, 1, 1, 0,
-                nullptr, nullptr, config_d));
+      hipModuleLaunchKernel(f_kernel, 1, 1, 1, 1, 1, 1, 0,
+          nullptr, nullptr, config_d);
       HIP_CHECK(hipDeviceSynchronize());
       REQUIRE(A_h[0] == INITIAL_VAL);
       REQUIRE(*result == 0);
@@ -306,8 +306,8 @@ TEMPLATE_TEST_CASE("Unit_unsafeAtomicAdd_CoherentRTCwithoutflag", "",
       void* config_d[] = {HIP_LAUNCH_PARAM_BUFFER_POINTER, &args_f,
                           HIP_LAUNCH_PARAM_BUFFER_SIZE,
                           &size, HIP_LAUNCH_PARAM_END};
-      HIP_CHECK(hipModuleLaunchKernel(f_kernel, 1, 1, 1, 1, 1,
-                            1, 0, nullptr, nullptr, config_d));
+      hipModuleLaunchKernel(f_kernel, 1, 1, 1, 1, 1,
+                            1, 0, nullptr, nullptr, config_d);
       HIP_CHECK(hipDeviceSynchronize());
       REQUIRE(A_h[0] == INITIAL_VAL);
       REQUIRE(*result == 0);
@@ -392,8 +392,8 @@ TEMPLATE_TEST_CASE("Unit_unsafeAtomicAdd_NonCoherentRTCnounsafeatomicflag", "",
       void* config_d[] = {HIP_LAUNCH_PARAM_BUFFER_POINTER, &args_f,
         HIP_LAUNCH_PARAM_BUFFER_SIZE,
         &size, HIP_LAUNCH_PARAM_END};
-      HIP_CHECK(hipModuleLaunchKernel(f_kernel, 1, 1, 1, 1, 1, 1, 0,
-                            nullptr, nullptr, config_d));
+      hipModuleLaunchKernel(f_kernel, 1, 1, 1, 1, 1, 1, 0,
+                            nullptr, nullptr, config_d);
       HIP_CHECK(hipDeviceSynchronize());
       REQUIRE(A_h[0] == INITIAL_VAL + INCREMENT_VAL);
       REQUIRE(*result == INITIAL_VAL);
@@ -480,8 +480,8 @@ TEMPLATE_TEST_CASE("Unit_unsafeAtomicAdd_NonCoherentRTCunsafeatomicflag", "",
       void* config_d[] = {HIP_LAUNCH_PARAM_BUFFER_POINTER, &args_f,
         HIP_LAUNCH_PARAM_BUFFER_SIZE,
         &size, HIP_LAUNCH_PARAM_END};
-      HIP_CHECK(hipModuleLaunchKernel(f_kernel, 1, 1, 1, 1, 1, 1, 0,
-                            nullptr, nullptr, config_d));
+      hipModuleLaunchKernel(f_kernel, 1, 1, 1, 1, 1, 1, 0,
+                            nullptr, nullptr, config_d);
       HIP_CHECK(hipDeviceSynchronize());
       REQUIRE(A_h[0] == INITIAL_VAL + INCREMENT_VAL);
       REQUIRE(*result == INITIAL_VAL);
@@ -568,8 +568,8 @@ TEMPLATE_TEST_CASE("Unit_unsafeAtomicAdd_NonCoherentRTC", "",
       void* config_d[] = {HIP_LAUNCH_PARAM_BUFFER_POINTER, &args_f,
                           HIP_LAUNCH_PARAM_BUFFER_SIZE,
                           &size, HIP_LAUNCH_PARAM_END};
-      HIP_CHECK(hipModuleLaunchKernel(f_kernel, 1, 1, 1, 1, 1, 1, 0,
-                            nullptr, nullptr, config_d));
+      hipModuleLaunchKernel(f_kernel, 1, 1, 1, 1, 1, 1, 0,
+                            nullptr, nullptr, config_d);
       HIP_CHECK(hipDeviceSynchronize());
       REQUIRE(A_h[0] == INITIAL_VAL + INCREMENT_VAL);
       REQUIRE(*result == INITIAL_VAL);

--- a/catch/unit/graph/hipGraphCycle.cc
+++ b/catch/unit/graph/hipGraphCycle.cc
@@ -132,6 +132,7 @@ TEST_CASE("Unit_hipGraph_BasicCyclic4") {
 
   HipTest::initArrays<int>(&X_d, &Y_d, nullptr, &X_h, &Y_h, nullptr, N, false);
 
+  constexpr size_t memSetVal = 9;
   hipGraphNode_t kMemCpyH2D_X, memcpyD2D, memcpyD2H_RC, emptyNode1;
 
   HIP_CHECK(hipStreamCreate(&stream));
@@ -191,6 +192,7 @@ TEST_CASE("Unit_hipGraph_BasicCyclic5") {
 
   HipTest::initArrays<int>(&X_d, &Y_d, nullptr, &X_h, &Y_h, nullptr, N, false);
 
+  constexpr size_t memSetVal = 9;
   hipGraphNode_t kMemCpyH2D_X, memcpyD2D, memcpyD2H_RC, emptyNode1, emptyNode2, emptyNode3;
 
   HIP_CHECK(hipStreamCreate(&stream));

--- a/catch/unit/graph/hipStreamBeginCapture.cc
+++ b/catch/unit/graph/hipStreamBeginCapture.cc
@@ -22,7 +22,6 @@ THE SOFTWARE.
 #include <hip_test_defgroups.hh>
 #include "stream_capture_common.hh" // NOLINT
 
-#pragma clang diagnostic ignored "-Wunused-variable"
 /**
  * @addtogroup hipStreamBeginCapture hipStreamBeginCapture
  * @{

--- a/catch/unit/graph/user_object_common.hh
+++ b/catch/unit/graph/user_object_common.hh
@@ -24,8 +24,6 @@ THE SOFTWARE.
 
 #include <hip_test_common.hh>
 
-#pragma clang diagnostic ignored "-Wunused-function"
-
 struct BoxStruct {
   int count;
   BoxStruct() { INFO("Constructor called for Struct!\n"); }

--- a/catch/unit/kernel/hipShflTests.cc
+++ b/catch/unit/kernel/hipShflTests.cc
@@ -150,6 +150,7 @@ static void runTest() {
 
   // verify the results
   REQUIRE(errors == compare(TransposeMatrix, cpuTransposeMatrix));
+  double eps = 1.0E-6;
   // free the resources on device side
   HIP_CHECK(hipFree(gpuMatrix));
   HIP_CHECK(hipFree(gpuTransposeMatrix));

--- a/catch/unit/memory/hipArrayCommon.hh
+++ b/catch/unit/memory/hipArrayCommon.hh
@@ -43,7 +43,12 @@ __global__ void readFromTexture(T* output, hipTextureObject_t texObj, size_t wid
   } else {
     const float v = y / (float)height;
     if (textureGather) {
+      // tex2Dgather not supported on __gfx90a__
+      #if !defined(__gfx90a__)
       output[y * width + x] = tex2Dgather<T>(texObj, u, v, ChannelToRead);
+      #else
+      #warning("tex2Dgather not supported on gfx90a");
+      #endif
     } else {
       output[y * width + x] = tex2D<T>(texObj, u, v);
     }

--- a/catch/unit/memory/hipArrayCreate.cc
+++ b/catch/unit/memory/hipArrayCreate.cc
@@ -54,7 +54,7 @@ static void ArrayCreate_DiffSizes(int gpu) {
   std::vector<std::pair<size_t, size_t>> runs {std::make_pair(NUM_W, NUM_H), std::make_pair(BIGNUM_W, BIGNUM_H)};
   for (const auto& size : runs) {
     std::array<HIP_ARRAY, ARRAY_LOOP> array;
-    size_t pavail;
+    size_t pavail, avail;
     HIP_CHECK_THREAD(hipMemGetInfo(&pavail, nullptr));
     HIP_ARRAY_DESCRIPTOR desc;
     desc.NumChannels = 1;

--- a/catch/unit/memory/hipFreeAsync.cc
+++ b/catch/unit/memory/hipFreeAsync.cc
@@ -26,7 +26,7 @@ TEST_CASE("Unit_hipFreeAsync_negative") {
   HIP_CHECK(hipSetDevice(0));
   void* p = nullptr;
   hipStream_t stream{nullptr};
-  HIP_CHECK(hipStreamCreate(&stream));
+  hipStreamCreate(&stream);
 
   SECTION("dev_ptr is nullptr") { REQUIRE(hipFreeAsync(nullptr, stream) != hipSuccess); }
 

--- a/catch/unit/memory/hipMalloc3D.cc
+++ b/catch/unit/memory/hipMalloc3D.cc
@@ -43,7 +43,7 @@ static void MemoryAlloc3DDiffSizes(int gpu) {
     size_t height{sizes}, depth{sizes};
     hipPitchedPtr devPitchedPtr[CHUNK_LOOP];
     hipExtent extent = make_hipExtent(width, height, depth);
-    size_t ptot, pavail;
+    size_t tot, avail, ptot, pavail;
     HIPCHECK(hipMemGetInfo(&pavail, &ptot));
     for (int i = 0; i < CHUNK_LOOP; i++) {
       HIPCHECK(hipMalloc3D(&devPitchedPtr[i], extent));

--- a/catch/unit/memory/hipMallocArray.cc
+++ b/catch/unit/memory/hipMallocArray.cc
@@ -399,22 +399,12 @@ TEMPLATE_TEST_CASE("Unit_hipMallocArray_happy", "", uint, int, int4, ushort, sho
     testArrayAsSurface<TestType>(arrayPtr, width, height);
   }
   SECTION("hipArrayTextureGather") {
-    hipDeviceProp_t prop;
-    int device;
-    HIP_CHECK(hipGetDevice(&device));
-    HIP_CHECK(hipGetDeviceProperties(&prop, device));
-    // tex2Dgather not supported on gfx90a
-    if (std::string(prop.gcnArchName).find("gfx90a") == std::string::npos) {
-      height = 1024;
-      INFO("flag is hipArrayTextureGather");
-      INFO("height: " << height);
+    height = 1024;
+    INFO("flag is hipArrayTextureGather");
+    INFO("height: " << height);
 
-      HIP_CHECK(hipMallocArray(&arrayPtr, &desc, width, height, hipArrayTextureGather));
-      testArrayAsTextureWithGather<TestType>(arrayPtr, width, height);
-    } else {
-      SUCCEED("tex2Dgather is not supported for gfx90a, Hence"
-               "skipping the testcase for this device " << device);
-    }
+    HIP_CHECK(hipMallocArray(&arrayPtr, &desc, width, height, hipArrayTextureGather));
+    testArrayAsTextureWithGather<TestType>(arrayPtr, width, height);
   }
 #endif
 

--- a/catch/unit/memory/hipMallocConcurrency.cc
+++ b/catch/unit/memory/hipMallocConcurrency.cc
@@ -82,7 +82,7 @@ static std::atomic<bool> g_thTestPassed{true};
 /**
  * Validates data consistency on supplied gpu
  */
-static bool validateMemoryOnGPU(int gpu) {
+static bool validateMemoryOnGPU(int gpu, bool concurOnOneGPU = false) {
   int *A_d, *B_d, *C_d;
   int *A_h, *B_h, *C_h;
   bool TestPassed = true;
@@ -148,7 +148,7 @@ static bool regressAllocInLoop(int gpu) {
  * Validates data consistency on supplied gpu
  * In Multithreaded Environment
  */
-static bool validateMemoryOnGpuMThread(int gpu) {
+static bool validateMemoryOnGpuMThread(int gpu, bool concurOnOneGPU = false) {
   int *A_d, *B_d, *C_d;
   int *A_h, *B_h, *C_h;
   bool TestPassed = true;
@@ -213,7 +213,7 @@ static bool regressAllocInLoopMthread(int gpu) {
  * Thread func to regress alloc and check data consistency
  */
 static void threadFunc(int gpu) {
-  g_thTestPassed = regressAllocInLoopMthread(gpu) && validateMemoryOnGpuMThread(gpu);
+  g_thTestPassed = regressAllocInLoopMthread(gpu) && validateMemoryOnGpuMThread(gpu, true);
 
   UNSCOPED_INFO("thread execution status on gpu" << gpu << ":" << g_thTestPassed.load());
 }

--- a/catch/unit/memory/hipMemAdviseMmap.cc
+++ b/catch/unit/memory/hipMemAdviseMmap.cc
@@ -31,7 +31,7 @@ THE SOFTWARE.
 */
 
 TEST_CASE("Unit_hipMemAdvise_MmapMem") {
-  int managed = 0, PageableMem = 0;
+  int managed = 0, NUM_ELMS = 212992, PageableMem = 0;
   INFO("The following are the attribute values related to HMM for"
          " device 0:\n");
   HIP_CHECK(hipDeviceGetAttribute(&managed,
@@ -54,7 +54,6 @@ TEST_CASE("Unit_hipMemAdvise_MmapMem") {
 #ifdef __linux__
     // For now this test is enabled only for linux platforms
     FILE *fptr;
-    int NUM_ELMS = 212992;
     fptr = fopen("ForTest1.txt", "w");
     for (int m = 0; m < NUM_ELMS; ++m) {
       putw(m, fptr);

--- a/catch/unit/memory/hipMemAdvise_old.cc
+++ b/catch/unit/memory/hipMemAdvise_old.cc
@@ -666,6 +666,7 @@ TEST_CASE("Unit_hipMemAdvise_TstAlignedAllocMem") {
   std::string gfxName(prop.gcnArchName);
 
   if (gfxName.find("xnack+") != std::string::npos) {
+    int stat = 0;
     int managedMem = 0, pageMemAccess = 0;
     HIP_CHECK(hipDeviceGetAttribute(&pageMemAccess,
               hipDeviceAttributePageableMemoryAccess, 0));

--- a/catch/unit/memory/hipMemRangeGetAttributes_old.cc
+++ b/catch/unit/memory/hipMemRangeGetAttributes_old.cc
@@ -26,7 +26,6 @@ THE SOFTWARE.
 #include <hip_test_common.hh>
 #define MEM_SIZE 8192
 
-#ifdef __linux__
 static bool CheckError(hipError_t err, int LineNo) {
   if (err == hipSuccess) {
     WARN("Error expected but received hipSuccess at line no.:"
@@ -60,6 +59,7 @@ static int HmmAttrPrint() {
   return managed;
 }
 
+#ifdef __linux__
 /* Test Scenario: Testing basic working of hipMemRangeGetAttributes()
    api with different flags */
 

--- a/catch/unit/memory/hipMemcpy3D.cc
+++ b/catch/unit/memory/hipMemcpy3D.cc
@@ -28,8 +28,6 @@ THE SOFTWARE.
 #include <resource_guards.hh>
 #include <utils.hh>
 
-#pragma clang diagnostic ignored "-Wunused-variable"
-
 TEST_CASE("Unit_hipMemcpy3D_Positive_Basic") {
   constexpr bool async = false;
 

--- a/catch/unit/memory/hipMemcpy3DAsync.cc
+++ b/catch/unit/memory/hipMemcpy3DAsync.cc
@@ -28,8 +28,6 @@ THE SOFTWARE.
 #include <resource_guards.hh>
 #include <utils.hh>
 
-#pragma clang diagnostic ignored "-Wunused-variable"
-
 TEST_CASE("Unit_hipMemcpy3DAsync_Positive_Basic") {
   constexpr bool async = true;
 

--- a/catch/unit/rtc/linker.cc
+++ b/catch/unit/rtc/linker.cc
@@ -11,7 +11,8 @@
 #include <iterator>
 #include <vector>
 
-#pragma clang diagnostic ignored "-Wuninitialized"
+static constexpr auto NUM_THREADS{128};
+static constexpr auto NUM_BLOCKS{32};
 
 static constexpr auto src{
     R"(

--- a/catch/unit/stream/hipStreamCreateWithPriority.cc
+++ b/catch/unit/stream/hipStreamCreateWithPriority.cc
@@ -686,8 +686,8 @@ void TestForMultipleStreamWithPriority(void) {
   }
   // launch kernels repeatedly on each of the low prioritiy stream
   for (int k = 0; k < LOW_PRIORITY_STREAMCOUNT; ++k) {
-    for (size_t i = 0; i < size; i += MEMCPYSIZE1) {
-      size_t j = i / sizeof(T);
+    for (int i = 0; i < size; i += MEMCPYSIZE1) {
+      int j = i / sizeof(T);
       if (enable_priority_low) {
         hipLaunchKernelGGL((memcpy_kernel<T>), dim3(GRIDSIZE), dim3(BLOCKSIZE),
         0, stream_low[k], dst_d_low[k] + j, src_d_low[k] + j,
@@ -697,8 +697,8 @@ void TestForMultipleStreamWithPriority(void) {
   }
   // launch kernels repeatedly on each of the normal prioritiy stream
   for (int k = 0; k < NORMAL_PRIORITY_STREAMCOUNT; ++k) {
-    for (size_t i = 0; i < size; i += MEMCPYSIZE1) {
-      size_t j = i / sizeof(T);
+    for (int i = 0; i < size; i += MEMCPYSIZE1) {
+      int j = i / sizeof(T);
       if (enable_priority_normal) {
         hipLaunchKernelGGL((memcpy_kernel<T>), dim3(GRIDSIZE), dim3(BLOCKSIZE),
         0, stream_normal[k], dst_d_normal[k] + j, src_d_normal[k] + j,
@@ -708,8 +708,8 @@ void TestForMultipleStreamWithPriority(void) {
   }
   // launch kernels repeatedly on each of the high prioritiy stream
   for (int k = 0; k < HIGH_PRIORITY_STREAMCOUNT; ++k) {
-    for (size_t i = 0; i < size; i += MEMCPYSIZE1) {
-      size_t j = i / sizeof(T);
+    for (int i = 0; i < size; i += MEMCPYSIZE1) {
+      int j = i / sizeof(T);
       if (enable_priority_high) {
         hipLaunchKernelGGL((memcpy_kernel<T>), dim3(GRIDSIZE), dim3(BLOCKSIZE),
         0, stream_high[k], dst_d_high[k] + j, src_d_high[k] + j,

--- a/catch/unit/surface/hipSurfaceObj1D.cc
+++ b/catch/unit/surface/hipSurfaceObj1D.cc
@@ -19,7 +19,7 @@ THE SOFTWARE.
 #include <hip_test_common.hh>
 #include <hip_array_common.hh>
 #include <hip_texture_helper.hh>
-#pragma clang diagnostic ignored "-Wunused-variable"
+
 template <typename T>
 __global__ void
 surf1DKernelR(hipSurfaceObject_t surfaceObject,

--- a/catch/unit/surface/hipSurfaceObj2D.cc
+++ b/catch/unit/surface/hipSurfaceObj2D.cc
@@ -19,7 +19,7 @@ THE SOFTWARE.
 #include <hip_test_common.hh>
 #include <hip_array_common.hh>
 #include <hip_texture_helper.hh>
-#pragma clang diagnostic ignored "-Wunused-variable"
+
 #define LOG_DATA 0
 
 template <typename T>

--- a/catch/unit/surface/hipSurfaceObj3D.cc
+++ b/catch/unit/surface/hipSurfaceObj3D.cc
@@ -19,7 +19,7 @@ THE SOFTWARE.
 #include <hip_test_common.hh>
 #include <hip_array_common.hh>
 #include <hip_texture_helper.hh>
-#pragma clang diagnostic ignored "-Wunused-variable"
+
 template <typename T>
 __global__ void
 surf3DKernelR(hipSurfaceObject_t surfaceObject,

--- a/catch/unit/texture/hipTextureMipmapObj2D.cc
+++ b/catch/unit/texture/hipTextureMipmapObj2D.cc
@@ -104,7 +104,7 @@ static void runMipMapTest(unsigned int width, unsigned int height, unsigned int 
   hipLaunchKernelGGL(tex2DKernel, dim3(dimGrid), dim3(dimBlock), 0, 0, dData, textureObject, width,
                      (2 * mipmap_level));
   HIP_CHECK(hipGetLastError()); 
-  HIP_CHECK(hipDeviceSynchronize());
+  hipDeviceSynchronize();
 
   float* hOutputData = reinterpret_cast<float*>(malloc(size));
   REQUIRE(hOutputData != nullptr);

--- a/catch/unit/texture/hipTextureObjFetchVector.cc
+++ b/catch/unit/texture/hipTextureObjFetchVector.cc
@@ -21,7 +21,7 @@ THE SOFTWARE.
 #include <hip_array_common.hh>
 #include <vector>
 #include <iostream>
-#pragma clang diagnostic ignored "-Wunused-variable"
+
 template <typename T>
 __global__ void tex1dKernelFetch(T *val, hipTextureObject_t obj, int N) {
 #if !defined(__HIP_NO_IMAGE_SUPPORT) || !__HIP_NO_IMAGE_SUPPORT
@@ -79,7 +79,7 @@ bool runTest() {
   // Allocating the required buffer on gpu device
   T *texBuf, *texBufOut;
   T val[N], output[N];
-  auto err = hipGetLastError(); // Clear err due to negative tests
+  hipGetLastError(); // Clear err due to negative tests
   memset(output, 0, sizeof(output));
   std::srand(std::time(nullptr)); // use current time as seed for random generator
 

--- a/samples/0_Intro/bit_extract/CMakeLists.txt
+++ b/samples/0_Intro/bit_extract/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 - 2023 Advanced Micro Devices, Inc. All Rights Reserved.
+# Copyright (c) 2020 - 2021 Advanced Micro Devices, Inc. All Rights Reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -26,9 +26,16 @@ if(NOT WIN32 AND NOT DEFINED __HIP_ENABLE_PCH)
   set(__HIP_ENABLE_PCH ON CACHE BOOL "enable/disable pre-compiled hip headers")
 endif()
 
+if (NOT DEFINED ROCM_PATH )
+     set ( ROCM_PATH "/opt/rocm"  CACHE STRING "Default ROCM installation directory." )
+endif ()
+
 if(${__HIP_ENABLE_PCH})
   add_definitions(-D__HIP_ENABLE_PCH)
 endif()
+
+# Search for rocm in common locations
+list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/hip ${ROCM_PATH})
 
 # Find hip
 find_package(hip)

--- a/samples/0_Intro/bit_extract/Makefile
+++ b/samples/0_Intro/bit_extract/Makefile
@@ -1,0 +1,47 @@
+# Copyright (c) 2016 - 2021 Advanced Micro Devices, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+#Dependencies : [MYHIP]/bin must be in user's path.
+ifeq ($(OS),Windows_NT)
+ $(error Makefile is not supported on windows platform. Please use cmake instead to build sample.)
+endif
+ROCM_PATH?= $(wildcard /opt/rocm/)
+HIP_PATH?= $(wildcard $(ROCM_PATH)/hip)
+ifeq (,$(HIP_PATH))
+	HIP_PATH=../../..
+endif
+HIP_PLATFORM=$(shell $(HIP_PATH)/bin/hipconfig --platform)
+HIPCC=$(HIP_PATH)/bin/hipcc
+INCLUDES  := -I../../common
+
+# Show how to use PLATFORM to specify different options for each compiler:
+ifeq (${HIP_PLATFORM}, nvcc)
+	HIPCC_FLAGS = -gencode=arch=compute_20,code=sm_20
+endif
+
+EXE=bit_extract
+
+$(EXE): bit_extract.cpp
+	$(HIPCC) $(HIPCC_FLAGS) $(INCLUDES) $< -o $@
+
+all: $(EXE)
+
+clean:
+	rm -f *.o $(EXE)

--- a/samples/0_Intro/bit_extract/README.md
+++ b/samples/0_Intro/bit_extract/README.md
@@ -1,6 +1,6 @@
 # bit_extract
 
 Show an application written directly in HIP which uses platform-specific check on __HIP_PLATFORM_AMD__ to enable use of
-an instruction that only exists on the AMD platform.
+an instruction that only exists on the HCC platform.
 
 See related [blog](http://gpuopen.com/platform-aware-coding-inside-hip/) demonstrating platform specialization.

--- a/samples/0_Intro/module_api/CMakeLists.txt
+++ b/samples/0_Intro/module_api/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 - 2023 Advanced Micro Devices, Inc. All Rights Reserved.
+# Copyright (c) 2020 - 2021 Advanced Micro Devices, Inc. All Rights Reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,6 +23,14 @@ project(module_api)
 cmake_minimum_required(VERSION 3.10)
 
 include_directories(../../common)
+
+if (NOT DEFINED ROCM_PATH )
+     set ( ROCM_PATH "/opt/rocm"  CACHE STRING "Default ROCM installation directory." )
+endif ()
+
+# Search for rocm in common locations
+list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/hip ${ROCM_PATH})
+
 # Find hip
 find_package(hip)
 

--- a/samples/0_Intro/module_api/Makefile
+++ b/samples/0_Intro/module_api/Makefile
@@ -1,0 +1,47 @@
+# Copyright (c) 2016 - 2021 Advanced Micro Devices, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+ifeq ($(OS),Windows_NT)
+ $(error Makefile is not supported on windows platform. Please use cmake instead to build sample.)
+endif
+ROCM_PATH?= $(wildcard /opt/rocm/)
+HIP_PATH?= $(wildcard $(ROCM_PATH)/hip)
+ifeq (,$(HIP_PATH))
+	HIP_PATH=../../..
+endif
+HIPCC=$(HIP_PATH)/bin/hipcc
+HIP_PLATFORM=$(shell $(HIP_PATH)/bin/hipconfig --compiler)
+INCLUDES  := -I../../common
+
+all: vcpy_kernel.code runKernel.hip.out launchKernelHcc.hip.out defaultDriver.hip.out
+
+runKernel.hip.out: runKernel.cpp
+	$(HIPCC) $(HIPCC_FLAGS) $(INCLUDES) $< -o $@
+
+launchKernelHcc.hip.out: launchKernelHcc.cpp
+	$(HIPCC) $(HIPCC_FLAGS) $(INCLUDES) $< -o $@
+
+defaultDriver.hip.out: defaultDriver.cpp
+	$(HIPCC)  $(HIPCC_FLAGS) $(INCLUDES) $< -o $@
+
+vcpy_kernel.code: vcpy_kernel.cpp
+	$(HIPCC)  --genco  $(GENCO_FLAGS) $(INCLUDES) $^ -o $@
+
+clean:
+	rm -f *.code *.out

--- a/samples/0_Intro/module_api_global/CMakeLists.txt
+++ b/samples/0_Intro/module_api_global/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 - 2023 Advanced Micro Devices, Inc. All Rights Reserved.
+# Copyright (c) 2020 - 2021 Advanced Micro Devices, Inc. All Rights Reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -18,9 +18,16 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-project(module_api_global)
+project(modile_api_global)
 
 cmake_minimum_required(VERSION 3.10)
+
+if (NOT DEFINED ROCM_PATH )
+     set ( ROCM_PATH "/opt/rocm"  CACHE STRING "Default ROCM installation directory." )
+endif ()
+
+# Search for rocm in common locations
+list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/hip ${ROCM_PATH})
 
 # Find hip
 find_package(hip)

--- a/samples/0_Intro/module_api_global/Makefile
+++ b/samples/0_Intro/module_api_global/Makefile
@@ -1,0 +1,41 @@
+# Copyright (c) 2017 - 2021 Advanced Micro Devices, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+ifeq ($(OS),Windows_NT)
+ $(error Makefile is not supported on windows platform. Please use cmake instead to build sample.)
+endif
+ROCM_PATH?= $(wildcard /opt/rocm/)
+HIP_PATH?= $(wildcard $(ROCM_PATH)/hip)
+ifeq (,$(HIP_PATH))
+	HIP_PATH=../../..
+endif
+HIPCC=$(HIP_PATH)/bin/hipcc
+HIP_PLATFORM=$(shell $(HIP_PATH)/bin/hipconfig --compiler)
+INCLUDES  := -I../../common
+
+all: vcpy_kernel.code runKernel.hip.out
+
+runKernel.hip.out: runKernel.cpp
+	$(HIPCC) $(HIPCC_FLAGS) $(INCLUDES) $< -o $@
+
+vcpy_kernel.code: vcpy_kernel.cpp
+	$(HIPCC)  --genco  $(GENCO_FLAGS) $^ -o $@
+
+clean:
+	rm -f *.code *.out

--- a/samples/0_Intro/square/CMakeLists.txt
+++ b/samples/0_Intro/square/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 - 2023 Advanced Micro Devices, Inc. All Rights Reserved.
+# Copyright (c) 2020 - 2021 Advanced Micro Devices, Inc. All Rights Reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -24,8 +24,15 @@ project(square)
 
 cmake_minimum_required(VERSION 3.10)
 
+if (NOT DEFINED ROCM_PATH )
+     set ( ROCM_PATH "/opt/rocm"  CACHE STRING "Default ROCM installation directory." )
+endif ()
+
+# Search for rocm in common locations
+list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/hip ${ROCM_PATH})
+
 # create square.cpp
-execute_process(COMMAND sh -c "${CMAKE_PREFIX_PATH}/hip/bin/hipify-perl ../square.cu > ../square.cpp")
+execute_process(COMMAND sh -c "${ROCM_PATH}/hip/bin/hipify-perl ../square.cu > ../square.cpp")
 
 # Find hip
 find_package(hip)

--- a/samples/0_Intro/square/Makefile
+++ b/samples/0_Intro/square/Makefile
@@ -1,0 +1,47 @@
+# Copyright (c) 2016 - 2021 Advanced Micro Devices, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+ifeq ($(OS),Windows_NT)
+ $(error Makefile is not supported on windows platform. Please use cmake instead to build sample.)
+endif
+ROCM_PATH?= $(wildcard /opt/rocm/)
+HIP_PATH?= $(wildcard $(ROCM_PATH)/hip)
+ifeq (,$(HIP_PATH))
+	HIP_PATH=../../..
+endif
+HIP_PLATFORM=$(shell $(HIP_PATH)/bin/hipconfig --platform)
+HIPCC=$(HIP_PATH)/bin/hipcc
+
+ifeq (${HIP_PLATFORM}, nvidia)
+	SOURCES=square.cu
+else
+	SOURCES=square.cpp
+endif
+
+all: square.out
+
+# Step
+square.cpp: square.cu
+	$(HIP_PATH)/bin/hipify-perl square.cu > square.cpp
+
+square.out: $(SOURCES)
+	$(HIPCC) $(CXXFLAGS) $(SOURCES) -o $@
+
+clean:
+	rm -f *.o *.out square.cpp

--- a/samples/0_Intro/square/README.md
+++ b/samples/0_Intro/square/README.md
@@ -14,16 +14,11 @@ $ export PATH=$PATH:[MYHIP]/bin
 $ export HIP_PATH=[MYHIP]
 ```
 
-- Build executable file
+- Build executible file
 
 ```
 $ cd ~/hip/samples/0_Intro/square
-  mkdir -p build && cd build
-
-  cmake -DCMAKE_PREFIX_PATH=<path/to/rocm> -DHIP_CXX_COMPILER=<path/to/clang> ..
-  make
-
-$ Building without cmake
+$ make
 /opt/rocm/hip/bin/hipify-perl square.cu > square.cpp
 /opt/rocm/hip/bin/hipcc  square.cpp -o square.out
 /opt/rocm/hip/bin/hipcc -use-staticlib  square.cpp -o square.out.static

--- a/samples/1_Utils/hipDispatchLatency/CMakeLists.txt
+++ b/samples/1_Utils/hipDispatchLatency/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 - 2023 Advanced Micro Devices, Inc. All Rights Reserved.
+# Copyright (c) 2020 - 2021 Advanced Micro Devices, Inc. All Rights Reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,6 +23,14 @@ project(hipDispatchLatency)
 cmake_minimum_required(VERSION 3.10)
 
 include_directories(../../common)
+
+if (NOT DEFINED ROCM_PATH )
+     set ( ROCM_PATH "/opt/rocm"  CACHE STRING "Default ROCM installation directory." )
+endif ()
+
+# Search for rocm in common locations
+list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/hip ${ROCM_PATH})
+
 # Find hip
 find_package(hip)
 

--- a/samples/1_Utils/hipDispatchLatency/Makefile
+++ b/samples/1_Utils/hipDispatchLatency/Makefile
@@ -1,0 +1,44 @@
+# Copyright (c) 2016 - 2021 Advanced Micro Devices, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+ifeq ($(OS),Windows_NT)
+ $(error Makefile is not supported on windows platform. Please use cmake instead to build sample.)
+endif
+ROCM_PATH?= $(wildcard /opt/rocm/)
+HIP_PATH?= $(wildcard $(ROCM_PATH)/hip)
+ifeq (,$(HIP_PATH))
+	HIP_PATH=../../..
+endif
+HIPCC=$(HIP_PATH)/bin/hipcc -std=c++11
+INCLUDES  := -I../../common
+
+CXXFLAGS = -O3 $(INCLUDES)
+
+all: test_kernel.code hipDispatchLatency.out hipDispatchEnqueueRateMT.out
+
+hipDispatchLatency.out: hipDispatchLatency.cpp
+	$(HIPCC) $(CXXFLAGS) hipDispatchLatency.cpp -o $@
+
+hipDispatchEnqueueRateMT.out: hipDispatchEnqueueRateMT.cpp
+	$(HIPCC) $(CXXFLAGS) hipDispatchEnqueueRateMT.cpp -lpthread -o $@
+
+test_kernel.code: test_kernel.cpp
+	$(HIP_PATH)/bin/hipcc --genco  $(GENCO_FLAGS) $^ -o $@
+clean:
+	rm -f *.o *.out

--- a/samples/1_Utils/hipInfo/CMakeLists.txt
+++ b/samples/1_Utils/hipInfo/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 - 2023 Advanced Micro Devices, Inc. All Rights Reserved.
+# Copyright (c) 2020 - 2021 Advanced Micro Devices, Inc. All Rights Reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -30,10 +30,17 @@ cmake_minimum_required(VERSION 3.10)
 # flag is set to ON in compute build for windows
 option(HIPINFO_INTERNAL_BUILD "Enable building hipInfo from compute" OFF)
 
+if (NOT DEFINED ROCM_PATH )
+     set ( ROCM_PATH "/opt/rocm"  CACHE STRING "Default ROCM installation directory." )
+endif ()
+
+# Search for rocm in common locations
+list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/hip ${ROCM_PATH})
+
 # need to set rocm_path for windows
 # since clang and hip are two different folders during build/install step
 if (WIN32 AND HIPINFO_INTERNAL_BUILD)
-     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --rocm-path=${CMAKE_PREFIX_PATH}")
+     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --rocm-path=${HIP_PATH}")
 endif()
 
 # Find hip

--- a/samples/1_Utils/hipInfo/Makefile
+++ b/samples/1_Utils/hipInfo/Makefile
@@ -1,0 +1,43 @@
+# Copyright (c) 2016 - 2021 Advanced Micro Devices, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+ifeq ($(OS),Windows_NT)
+ $(error Makefile is not supported on windows platform. Please use cmake instead to build sample.)
+endif
+ROCM_PATH?= $(wildcard /opt/rocm/)
+HIP_PATH?= $(wildcard $(ROCM_PATH)/hip)
+ifeq (,$(HIP_PATH))
+	HIP_PATH=../../..
+endif
+HIPCC=$(HIP_PATH)/bin/hipcc
+INCLUDES  := -I../../common
+
+EXE=hipInfo
+
+all: install
+
+$(EXE): hipInfo.cpp
+	$(HIPCC) hipInfo.cpp $(INCLUDES) -o $@
+
+install: $(EXE)
+	cp $(EXE) $(HIP_PATH)/bin
+
+
+clean:
+	rm -f *.o $(EXE)

--- a/samples/2_Cookbook/0_MatrixTranspose/CMakeLists.txt
+++ b/samples/2_Cookbook/0_MatrixTranspose/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 - 2023 Advanced Micro Devices, Inc. All Rights Reserved.
+# Copyright (c) 2020 - 2021 Advanced Micro Devices, Inc. All Rights Reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -21,6 +21,13 @@
 project(MatrixTranspose)
 
 cmake_minimum_required(VERSION 3.10)
+
+if (NOT DEFINED ROCM_PATH )
+     set ( ROCM_PATH "/opt/rocm"  CACHE STRING "Default ROCM installation directory." )
+endif ()
+
+# Search for rocm in common locations
+list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/hip ${ROCM_PATH})
 
 # Find hip
 find_package(hip)

--- a/samples/2_Cookbook/0_MatrixTranspose/Makefile
+++ b/samples/2_Cookbook/0_MatrixTranspose/Makefile
@@ -1,0 +1,60 @@
+# Copyright (c) 2016 - 2021 Advanced Micro Devices, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+ifeq ($(OS),Windows_NT)
+ $(error Makefile is not supported on windows platform. Please use cmake instead to build sample.)
+endif
+ROCM_PATH?= $(wildcard /opt/rocm/)
+HIP_PATH?= $(wildcard $(ROCM_PATH)/hip)
+ifeq (,$(HIP_PATH))
+	HIP_PATH=../../..
+endif
+
+HIPCC=$(HIP_PATH)/bin/hipcc
+
+TARGET=hcc
+
+INCLUDES  := -I../../common
+SOURCES = MatrixTranspose.cpp
+OBJECTS = $(SOURCES:.cpp=.o)
+
+EXECUTABLE=./MatrixTranspose
+
+.PHONY: test
+
+
+all: $(EXECUTABLE) test
+
+CXXFLAGS =-g $(INCLUDES)
+CXX=$(HIPCC)
+
+
+$(EXECUTABLE): $(OBJECTS)
+	$(HIPCC) $(OBJECTS) -o $@
+
+
+test: $(EXECUTABLE)
+	$(EXECUTABLE)
+
+
+clean:
+	rm -f $(EXECUTABLE)
+	rm -f $(OBJECTS)
+	rm -f $(HIP_PATH)/src/*.o
+

--- a/samples/2_Cookbook/10_inline_asm/CMakeLists.txt
+++ b/samples/2_Cookbook/10_inline_asm/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 - 2023 Advanced Micro Devices, Inc. All Rights Reserved.
+# Copyright (c) 2020 - 2021 Advanced Micro Devices, Inc. All Rights Reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -21,6 +21,13 @@
 project(inline_asm)
 
 cmake_minimum_required(VERSION 3.10)
+
+if (NOT DEFINED ROCM_PATH )
+     set ( ROCM_PATH "/opt/rocm"  CACHE STRING "Default ROCM installation directory." )
+endif ()
+
+# Search for rocm in common locations
+list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/hip ${ROCM_PATH})
 
 # Find hip
 find_package(hip)

--- a/samples/2_Cookbook/10_inline_asm/Makefile
+++ b/samples/2_Cookbook/10_inline_asm/Makefile
@@ -1,0 +1,58 @@
+# Copyright (c) 2017 - 2021 Advanced Micro Devices, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+ifeq ($(OS),Windows_NT)
+ $(error Makefile is not supported on windows platform. Please use cmake instead to build sample.)
+endif
+ROCM_PATH?= $(wildcard /opt/rocm/)
+HIP_PATH?= $(wildcard $(ROCM_PATH)/hip)
+ifeq (,$(HIP_PATH))
+	HIP_PATH=../../..
+endif
+
+HIPCC=$(HIP_PATH)/bin/hipcc
+
+TARGET=hcc
+
+SOURCES = inline_asm.cpp
+OBJECTS = $(SOURCES:.cpp=.o)
+INCLUDES  := -I../../common
+EXECUTABLE=./inline_asm
+
+.PHONY: test
+
+
+all: $(EXECUTABLE) test
+
+CXXFLAGS =-g $(INCLUDES)
+CXX=$(HIPCC)
+
+
+$(EXECUTABLE): $(OBJECTS)
+	$(HIPCC) $(OBJECTS) -o $@
+
+
+test: $(EXECUTABLE)
+	$(EXECUTABLE)
+
+
+clean:
+	rm -f $(EXECUTABLE)
+	rm -f $(OBJECTS)
+

--- a/samples/2_Cookbook/11_texture_driver/CMakeLists.txt
+++ b/samples/2_Cookbook/11_texture_driver/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 - 2023 Advanced Micro Devices, Inc. All Rights Reserved.
+# Copyright (c) 2020 - 2021 Advanced Micro Devices, Inc. All Rights Reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -21,6 +21,13 @@
 project(texture2dDrv)
 
 cmake_minimum_required(VERSION 3.10)
+
+if (NOT DEFINED ROCM_PATH )
+     set ( ROCM_PATH "/opt/rocm"  CACHE STRING "Default ROCM installation directory." )
+endif ()
+
+# Search for rocm in common locations
+list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/hip ${ROCM_PATH})
 
 # Find hip
 find_package(hip)

--- a/samples/2_Cookbook/11_texture_driver/Makefile
+++ b/samples/2_Cookbook/11_texture_driver/Makefile
@@ -1,0 +1,41 @@
+# Copyright (c) 2017 - 2021 Advanced Micro Devices, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+ifeq ($(OS),Windows_NT)
+ $(error Makefile is not supported on windows platform. Please use cmake instead to build sample.)
+endif
+ROCM_PATH?= $(wildcard /opt/rocm/)
+HIP_PATH?= $(wildcard $(ROCM_PATH)/hip)
+ifeq (,$(HIP_PATH))
+	HIP_PATH=../../..
+endif
+HIPCC=$(HIP_PATH)/bin/hipcc
+HIP_PLATFORM=$(shell $(HIP_PATH)/bin/hipconfig --compiler)
+INCLUDES  := -I../../common
+
+all: tex2dKernel.code texture2dDrv.out
+
+texture2dDrv.out: texture2dDrv.cpp
+	$(HIPCC) $(HIPCC_FLAGS) $(INCLUDES) $< -o $@
+	
+tex2dKernel.code: tex2dKernel.cpp
+	$(HIPCC)  --genco  $(GENCO_FLAGS) $^ -o $@
+
+clean:
+	rm -f *.code *.out

--- a/samples/2_Cookbook/13_occupancy/CMakeLists.txt
+++ b/samples/2_Cookbook/13_occupancy/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 - 2023 Advanced Micro Devices, Inc. All Rights Reserved.
+# Copyright (c) 2020 - 2021 Advanced Micro Devices, Inc. All Rights Reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -21,6 +21,13 @@
 project(occupancy)
 
 cmake_minimum_required(VERSION 3.10)
+
+if (NOT DEFINED ROCM_PATH )
+     set ( ROCM_PATH "/opt/rocm"  CACHE STRING "Default ROCM installation directory." )
+endif ()
+
+# Search for rocm in common locations
+list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/hip ${ROCM_PATH})
 
 # Find hip
 find_package(hip)

--- a/samples/2_Cookbook/13_occupancy/Makefile
+++ b/samples/2_Cookbook/13_occupancy/Makefile
@@ -1,0 +1,43 @@
+# Copyright (c) 2019 - 2021 Advanced Micro Devices, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+ifeq ($(OS),Windows_NT)
+ $(error Makefile is not supported on windows platform. Please use cmake instead to build sample.)
+endif
+ROCM_PATH?= $(wildcard /opt/rocm/)
+HIP_PATH?= $(wildcard $(ROCM_PATH)/hip)
+ifeq (,$(HIP_PATH))
+	HIP_PATH=../../..
+endif
+HIPCC=$(HIP_PATH)/bin/hipcc
+INCLUDES  := -I../../common
+EXE=./occupancy
+
+.PHONY: test
+
+all: test
+
+$(EXE): occupancy.cpp
+	$(HIPCC) $(INCLUDES) $^ -o $@
+
+test: $(EXE)
+	$(EXE)
+
+clean:
+	rm -f *.o $(EXE)

--- a/samples/2_Cookbook/14_gpu_arch/CMakeLists.txt
+++ b/samples/2_Cookbook/14_gpu_arch/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 - 2023 Advanced Micro Devices, Inc. All Rights Reserved.
+# Copyright (c) 2020 - 2021 Advanced Micro Devices, Inc. All Rights Reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -21,6 +21,13 @@
 project(gpuarch)
 
 cmake_minimum_required(VERSION 3.10)
+
+if (NOT DEFINED ROCM_PATH )
+     set ( ROCM_PATH "/opt/rocm"  CACHE STRING "Default ROCM installation directory." )
+endif ()
+
+# Search for rocm in common locations
+list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/hip ${ROCM_PATH})
 
 # Find hip
 find_package(hip)

--- a/samples/2_Cookbook/14_gpu_arch/Makefile
+++ b/samples/2_Cookbook/14_gpu_arch/Makefile
@@ -1,0 +1,43 @@
+# Copyright (c) 2020 - 2021 Advanced Micro Devices, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+ifeq ($(OS),Windows_NT)
+ $(error Makefile is not supported on windows platform. Please use cmake instead to build sample.)
+endif
+ROCM_PATH?= $(wildcard /opt/rocm/)
+HIP_PATH?= $(wildcard $(ROCM_PATH)/hip)
+ifeq (,$(HIP_PATH))
+	HIP_PATH=../../..
+endif
+HIPCC=$(HIP_PATH)/bin/hipcc
+INCLUDES  := -I../../common
+EXE=./gpuarch
+
+.PHONY: test
+
+all: test
+
+$(EXE): gpuarch.cpp
+	$(HIPCC) $(INCLUDES) $^ -o $@
+
+test: $(EXE)
+	$(EXE)
+
+clean:
+	rm -f *.o $(EXE)

--- a/samples/2_Cookbook/15_static_library/device_functions/CMakeLists.txt
+++ b/samples/2_Cookbook/15_static_library/device_functions/CMakeLists.txt
@@ -2,6 +2,13 @@ project(static_lib)
 
 cmake_minimum_required(VERSION 3.10)
 
+if (NOT DEFINED ROCM_PATH )
+     set ( ROCM_PATH "/opt/rocm"  CACHE STRING "Default ROCM installation directory." )
+endif ()
+
+# Search for rocm in common locations
+list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/hip ${ROCM_PATH})
+
 # Find hip
 find_package(hip REQUIRED)
 
@@ -31,7 +38,7 @@ add_library(HipDevice STATIC ${CPP_SOURCES})
 
 target_compile_options(HipDevice PRIVATE -fgpu-rdc)
 target_link_libraries(HipDevice PRIVATE -fgpu-rdc)
-target_include_directories(HipDevice PRIVATE ${CMAKE_PREFIX_PATH}/hsa/include)
+target_include_directories(HipDevice PRIVATE ${ROCM_PATH}/hsa/include)
 
 # Create test executable that uses libHipDevice.a
 set(TEST_SOURCES ${CMAKE_SOURCE_DIR}/hipMain2.cpp)

--- a/samples/2_Cookbook/15_static_library/device_functions/Makefile
+++ b/samples/2_Cookbook/15_static_library/device_functions/Makefile
@@ -1,0 +1,35 @@
+ifeq ($(OS),Windows_NT)
+ $(error Makefile is not supported on windows platform. Please use cmake instead to build sample.)
+endif
+ROCM_PATH?= $(wildcard /opt/rocm/)
+HIP_PATH?= $(wildcard $(ROCM_PATH)/hip)
+ifeq (,$(HIP_PATH))
+	HIP_PATH=../../..
+endif
+
+HIPCC=$(HIP_PATH)/bin/hipcc
+
+.PHONY: test
+
+all: $(RDC_EXE) test
+
+STATIC_LIB_SRC=hipDevice.cpp
+STATIC_LIB=./libHipDevice.a
+STATIC_MAIN_SRC=hipMain2.cpp
+RDC_EXE=./test_device_static.out
+
+$(STATIC_LIB):
+	$(HIPCC) $(STATIC_LIB_SRC) -c -fgpu-rdc -fPIC -o hipDevice.o
+	ar rcsD $@ hipDevice.o
+
+# Compiles hipMain2 with hipcc and links with libHipDevice.a which contains device function.
+$(RDC_EXE): $(STATIC_LIB)
+	$(HIPCC) $(STATIC_LIB) $(STATIC_MAIN_SRC) -fgpu-rdc -o $@
+
+test: $(RDC_EXE)
+	$(RDC_EXE)
+
+clean:
+	rm -f $(RDC_EXE)
+	rm -f $(STATIC_LIB)
+	rm -f *.o

--- a/samples/2_Cookbook/15_static_library/host_functions/CMakeLists.txt
+++ b/samples/2_Cookbook/15_static_library/host_functions/CMakeLists.txt
@@ -2,6 +2,13 @@ project(static_lib)
 
 cmake_minimum_required(VERSION 3.10)
 
+if (NOT DEFINED ROCM_PATH )
+     set ( ROCM_PATH "/opt/rocm"  CACHE STRING "Default ROCM installation directory." )
+endif ()
+
+# Search for rocm in common locations
+list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/hip ${ROCM_PATH})
+
 # Find hip
 find_package(hip REQUIRED)
 

--- a/samples/2_Cookbook/15_static_library/host_functions/Makefile
+++ b/samples/2_Cookbook/15_static_library/host_functions/Makefile
@@ -1,0 +1,42 @@
+ifeq ($(OS),Windows_NT)
+ $(error Makefile is not supported on windows platform. Please use cmake instead to build sample.)
+endif
+ROCM_PATH?= $(wildcard /opt/rocm/)
+HIP_PATH?= $(wildcard $(ROCM_PATH)/hip)
+ifeq (,$(HIP_PATH))
+	HIP_PATH=../../..
+endif
+
+HIPCC=$(HIP_PATH)/bin/hipcc
+GXX=g++
+
+EMIT_STATIC_LIB_SRC=hipOptLibrary.cpp
+EMIT_STATIC_LIB=./libHipOptLibrary.a
+EMIT_STATIC_MAIN_SRC=hipMain1.cpp
+HIPCC_EXE=./test_emit_static_hipcc_linker.out
+HOST_EXE=./test_emit_static_host_linker.out
+
+.PHONY: test
+
+all: $(HIPCC_EXE) $(HOST_EXE) test
+
+$(EMIT_STATIC_LIB):
+	$(HIPCC) $(EMIT_STATIC_LIB_SRC) --emit-static-lib -fPIC -o $@
+
+# Compiles hipMain1 with hipcc and links with libHipOptLibrary.a which contains host function.
+$(HIPCC_EXE): $(EMIT_STATIC_LIB)
+	$(HIPCC) $(EMIT_STATIC_MAIN_SRC) -L. -lHipOptLibrary -o $@
+
+# Compiles hipMain1 with g++ and links with libHipOptLibrary.a which contains host function.
+$(HOST_EXE): $(EMIT_STATIC_LIB)
+	$(GXX) $(EMIT_STATIC_MAIN_SRC) -L. -lHipOptLibrary -L$(HIP_PATH)/lib -lamdhip64 -Wl,-rpath=$(HIP_PATH)/lib -o $@
+
+test: $(HIPCC_EXE) $(HOST_EXE)
+	$(HIPCC_EXE)
+	$(HOST_EXE)
+
+clean:
+	rm -f $(HIPCC_EXE)
+	rm -f $(HOST_EXE)
+	rm -f $(EMIT_STATIC_LIB)
+	rm -f *.o

--- a/samples/2_Cookbook/16_assembly_to_executable/Makefile
+++ b/samples/2_Cookbook/16_assembly_to_executable/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 - 2023 Advanced Micro Devices, Inc. All Rights Reserved.
+# Copyright (c) 2020 - 2021 Advanced Micro Devices, Inc. All Rights Reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -22,6 +22,9 @@ ifeq ($(OS),Windows_NT)
 endif
 ROCM_PATH?= $(wildcard /opt/rocm/)
 HIP_PATH?= $(ROCM_PATH)
+ifeq (,$(HIP_PATH))
+	HIP_PATH=../../..
+endif
 
 HIPCC=$(HIP_PATH)/bin/hipcc
 CLANG=$(HIP_PATH)/llvm/bin/clang

--- a/samples/2_Cookbook/17_llvm_ir_to_executable/Makefile
+++ b/samples/2_Cookbook/17_llvm_ir_to_executable/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 - 2023 Advanced Micro Devices, Inc. All Rights Reserved.
+# Copyright (c) 2020 - 2021 Advanced Micro Devices, Inc. All Rights Reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -22,6 +22,9 @@ ifeq ($(OS),Windows_NT)
 endif
 ROCM_PATH?= $(wildcard /opt/rocm/)
 HIP_PATH?= $(ROCM_PATH)
+ifeq (,$(HIP_PATH))
+	HIP_PATH=../../..
+endif
 
 HIPCC=$(HIP_PATH)/bin/hipcc
 CLANG=$(HIP_PATH)/llvm/bin/clang

--- a/samples/2_Cookbook/1_hipEvent/CMakeLists.txt
+++ b/samples/2_Cookbook/1_hipEvent/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 - 2023 Advanced Micro Devices, Inc. All Rights Reserved.
+# Copyright (c) 2020 - 2021 Advanced Micro Devices, Inc. All Rights Reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -21,6 +21,13 @@
 project(hipEvent)
 
 cmake_minimum_required(VERSION 3.10)
+
+if (NOT DEFINED ROCM_PATH )
+     set ( ROCM_PATH "/opt/rocm"  CACHE STRING "Default ROCM installation directory." )
+endif ()
+
+# Search for rocm in common locations
+list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/hip ${ROCM_PATH})
 
 # Find hip
 find_package(hip)

--- a/samples/2_Cookbook/1_hipEvent/Makefile
+++ b/samples/2_Cookbook/1_hipEvent/Makefile
@@ -1,0 +1,58 @@
+# Copyright (c) 2016 - 2021 Advanced Micro Devices, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+ROCM_PATH?= $(wildcard /opt/rocm/)
+HIP_PATH?= $(wildcard $(ROCM_PATH)/hip)
+ifeq (,$(HIP_PATH))
+	HIP_PATH=../../..
+endif
+
+HIPCC=$(HIP_PATH)/bin/hipcc
+
+TARGET=hcc
+
+SOURCES = hipEvent.cpp
+OBJECTS = $(SOURCES:.cpp=.o)
+INCLUDES  := -I../../common
+
+EXECUTABLE=./hipEvent
+
+.PHONY: test
+
+
+all: $(EXECUTABLE) test
+
+CXXFLAGS =-g $(INCLUDES)
+CXX=$(HIPCC)
+
+
+$(EXECUTABLE): $(OBJECTS)
+	$(HIPCC) $(OBJECTS) -o $@
+
+
+test: $(EXECUTABLE)
+	$(EXECUTABLE)
+
+
+clean:
+	rm -f $(EXECUTABLE)
+	rm -f $(OBJECTS)
+	rm -f $(HIP_PATH)/src/*.o
+

--- a/samples/2_Cookbook/20_hip_vulkan/CMakeLists.txt
+++ b/samples/2_Cookbook/20_hip_vulkan/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-# Copyright (c) 2020 - 2023 Advanced Micro Devices, Inc. All Rights Reserved.
+# Copyright (c) 2020 - 2022 Advanced Micro Devices, Inc. All Rights Reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -29,10 +29,17 @@ project(hipVulkan)
 cmake_minimum_required(VERSION 3.10)
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake;${CMAKE_MODULE_PATH}")
 
+if (NOT DEFINED ROCM_PATH )
+     set ( ROCM_PATH "/opt/rocm"  CACHE STRING "Default ROCM installation directory." )
+endif ()
+
+# Search for rocm in common locations
+list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/hip ${ROCM_PATH})
+
 # need to set rocm_path for windows
 # since clang and hip are two different folders during build/install step
 if (WIN32 AND HIPINFO_INTERNAL_BUILD)
-     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --rocm-path=${CMAKE_PREFIX_PATH}")
+     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --rocm-path=${HIP_PATH}")
 endif()
 
 
@@ -78,7 +85,7 @@ set(CMAKE_BUILD_TYPE Release)
 
 # Create the excutable
 add_executable(hipVulkan VulkanBaseApp.cpp VulkanBaseApp.h main.cpp SineWaveSimulation.cpp SineWaveSimulation.h linmath.h)
-include_directories(${CMAKE_PREFIX_PATH}/include)
+include_directories(${HIP_PATH}/include)
 include_directories(${GLFW_PATH}/include)
 
 # Link with HIP

--- a/samples/2_Cookbook/20_hip_vulkan/SineWaveSimulation.hip
+++ b/samples/2_Cookbook/20_hip_vulkan/SineWaveSimulation.hip
@@ -1,0 +1,147 @@
+/* Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Modifications Copyright (C)2021 Advanced
+ * Micro Devices, Inc. All rights reserved.
+ */
+
+#include "SineWaveSimulation.h"
+#include <algorithm>
+//#include <helper_cuda.h>
+#include "hip/hip_runtime.h"
+
+
+__global__ void sinewave(float *heightMap, unsigned int width, unsigned int height, float time)
+{
+    const float freq = 4.0f;
+    const size_t stride = gridDim.x * blockDim.x;
+
+    // Iterate through the entire array in a way that is
+    // independent of the grid configuration
+    for (size_t tid = blockIdx.x * blockDim.x + threadIdx.x; tid < width * height; tid += stride) {
+        // Calculate the x, y coordinates
+        const size_t y = tid / width;
+        const size_t x = tid - y * width;
+        // Normalize x, y to [0,1]
+        const float u = ((2.0f * x) / width)  - 1.0f;
+        const float v = ((2.0f * y) / height) - 1.0f;
+        // Calculate the new height value
+        const float w = 0.5f * sinf(u * freq + time) * cosf(v * freq + time);
+        // Store this new height value
+        heightMap[tid] = w;
+    }
+}
+
+SineWaveSimulation::SineWaveSimulation(size_t width, size_t height) 
+                                        : m_heightMap(nullptr), m_width(width), m_height(height)
+{
+}
+
+void SineWaveSimulation::initCudaLaunchConfig(int device)
+{
+    hipDeviceProp_t prop = {};
+    checkHIPErrors(hipSetDevice(device));
+    checkHIPErrors(hipGetDeviceProperties(&prop, device));
+
+    // We don't need large block sizes, since there's not much inter-thread communication
+    m_threads = prop.warpSize;
+
+    // Use the occupancy calculator and fill the gpu as best as we can
+    checkHIPErrors(hipOccupancyMaxActiveBlocksPerMultiprocessor(&m_blocks, sinewave, prop.warpSize, 0));
+    m_blocks *= prop.multiProcessorCount;
+
+    // Go ahead and the clamp the blocks to the minimum needed for this height/width
+    m_blocks = std::min(m_blocks, (int)((m_width * m_height + m_threads - 1) / m_threads));
+}
+
+int SineWaveSimulation::initCuda(uint8_t  *vkDeviceUUID, size_t UUID_SIZE)
+{
+    int current_device = 0;
+    int device_count = 0;
+    int devices_prohibited = 0;
+
+    hipDeviceProp_t deviceProp;
+    checkHIPErrors(hipGetDeviceCount(&device_count));
+
+    if (device_count == 0) {
+        fprintf(stderr, "CUDA error: no devices supporting CUDA.\n");
+        exit(EXIT_FAILURE);
+    }
+
+    // Find the GPU which is selected by Vulkan
+    while (current_device < device_count) {
+        hipGetDeviceProperties(&deviceProp, current_device);
+
+        if ((deviceProp.computeMode != hipComputeModeProhibited)) {
+            // Compare the cuda device UUID with vulkan UUID
+            // FIXME
+            int ret = 0; // memcmp((void*)&deviceProp.uuid, vkDeviceUUID, UUID_SIZE);
+            if (ret == 0)
+            {
+                checkHIPErrors(hipSetDevice(current_device));
+                checkHIPErrors(hipGetDeviceProperties(&deviceProp, current_device));
+                printf("GPU Device %d: \"%s\" with compute capability %d.%d\n\n",
+                 current_device, deviceProp.name, deviceProp.major,
+                 deviceProp.minor);
+
+                return current_device;
+            }
+
+        } else {
+          devices_prohibited++;
+        }
+
+        current_device++;
+    }
+
+    if (devices_prohibited == device_count) {
+        fprintf(stderr,
+                "HIP error:"
+                " No Vulkan-HIP Interop capable GPU found.\n");
+        exit(EXIT_FAILURE);
+    }
+
+    return -1;
+}
+
+SineWaveSimulation::~SineWaveSimulation()
+{
+    m_heightMap = NULL;
+}
+ 
+void SineWaveSimulation::initSimulation(float *heights)
+{
+    m_heightMap = heights;
+}
+
+void SineWaveSimulation::stepSimulation(float time, hipStream_t stream)
+{
+    hipLaunchKernelGGL(sinewave, dim3(m_blocks), dim3(m_threads), 0, stream , m_heightMap, m_width, m_height, time);
+    getLastHIPError("Failed to launch CUDA simulation");
+    //hipStreamSynchronize(stream);
+}

--- a/samples/2_Cookbook/20_hip_vulkan/buildcmd.txt
+++ b/samples/2_Cookbook/20_hip_vulkan/buildcmd.txt
@@ -1,5 +1,3 @@
-Windows
---------
 •	Install hip and visual studio
 •	Install vulkan sdk from vulkan.lunarg.com
 •	Download GLFW binaries from glfw.org
@@ -15,16 +13,4 @@ to build without cmake:
 to build with cmake on windows:
 •       mkdir build; cd build
 •       cmake.exe -GNinja -DCMAKE_CXX_COMPILER_ID=ROCMClang -DCMAKE_C_COMPILER_ID=ROCMClang -DCMAKE_PREFIX_PATH=d:\driver2\drivers\drivers\compute\hip_sdk
-
-Linux
-------
-•	Ideally, vulkan should be picked up by cmake from the location where it is installed. eg: /usr/lib
-•	If a specific version of vulkan is needed, install vulkan sdk from vulkan.lunarg.com following the steps
-•       To run this sample, connect to the machine where display is enabled using NoMachine app
-
-Build with CMake:
-•       mkdir build; cd build
-•       cmake -DCMAKE_PREFIX_PATH=path\to\rocm -DHIP_CXX_COMPILER=path\to\clang
-•       make
-•       run hipVulkan executable
 

--- a/samples/2_Cookbook/3_shared_memory/CMakeLists.txt
+++ b/samples/2_Cookbook/3_shared_memory/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 - 2023 Advanced Micro Devices, Inc. All Rights Reserved.
+# Copyright (c) 2020 - 2021 Advanced Micro Devices, Inc. All Rights Reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -21,6 +21,13 @@
 project(sharedMemory)
 
 cmake_minimum_required(VERSION 3.10)
+
+if (NOT DEFINED ROCM_PATH )
+     set ( ROCM_PATH "/opt/rocm"  CACHE STRING "Default ROCM installation directory." )
+endif ()
+
+# Search for rocm in common locations
+list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/hip ${ROCM_PATH})
 
 # Find hip
 find_package(hip)

--- a/samples/2_Cookbook/3_shared_memory/Makefile
+++ b/samples/2_Cookbook/3_shared_memory/Makefile
@@ -1,0 +1,60 @@
+# Copyright (c) 2016 - 2021 Advanced Micro Devices, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+ifeq ($(OS),Windows_NT)
+ $(error Makefile is not supported on windows platform. Please use cmake instead to build sample.)
+endif
+ROCM_PATH?= $(wildcard /opt/rocm/)
+HIP_PATH?= $(wildcard $(ROCM_PATH)/hip)
+ifeq (,$(HIP_PATH))
+	HIP_PATH=../../..
+endif
+
+HIPCC=$(HIP_PATH)/bin/hipcc
+
+TARGET=hcc
+
+SOURCES = sharedMemory.cpp
+OBJECTS = $(SOURCES:.cpp=.o)
+INCLUDES  := -I../../common
+
+EXECUTABLE=./sharedMemory
+
+.PHONY: test
+
+
+all: $(EXECUTABLE) test
+
+CXXFLAGS =-g $(INCLUDES)
+CXX=$(HIPCC)
+
+
+$(EXECUTABLE): $(OBJECTS)
+	$(HIPCC) $(OBJECTS) -o $@
+
+
+test: $(EXECUTABLE)
+	$(EXECUTABLE)
+
+
+clean:
+	rm -f $(EXECUTABLE)
+	rm -f $(OBJECTS)
+	rm -f $(HIP_PATH)/src/*.o
+

--- a/samples/2_Cookbook/4_shfl/CMakeLists.txt
+++ b/samples/2_Cookbook/4_shfl/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 - 2023 Advanced Micro Devices, Inc. All Rights Reserved.
+# Copyright (c) 2020 - 2021 Advanced Micro Devices, Inc. All Rights Reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -21,6 +21,13 @@
 project(shfl)
 
 cmake_minimum_required(VERSION 3.10)
+
+if (NOT DEFINED ROCM_PATH )
+     set ( ROCM_PATH "/opt/rocm"  CACHE STRING "Default ROCM installation directory." )
+endif ()
+
+# Search for rocm in common locations
+list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/hip ${ROCM_PATH})
 
 # Find hip
 find_package(hip)

--- a/samples/2_Cookbook/4_shfl/Makefile
+++ b/samples/2_Cookbook/4_shfl/Makefile
@@ -1,0 +1,63 @@
+# Copyright (c) 2016 - 2021 Advanced Micro Devices, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+ifeq ($(OS),Windows_NT)
+ $(error Makefile is not supported on windows platform. Please use cmake instead to build sample.)
+endif
+ROCM_PATH?= $(wildcard /opt/rocm/)
+HIP_PATH?= $(wildcard $(ROCM_PATH)/hip)
+ifeq (,$(HIP_PATH))
+	HIP_PATH=../../..
+endif
+
+ifeq (gfx701, $(findstring gfx701,$(HCC_AMDGPU_TARGET)))
+	$(error gfx701 is not a supported device for this sample)
+endif
+
+HIPCC=$(HIP_PATH)/bin/hipcc
+
+TARGET=hcc
+
+SOURCES = shfl.cpp
+OBJECTS = $(SOURCES:.cpp=.o)
+INCLUDES  := -I../../common
+
+EXECUTABLE=./shfl
+
+.PHONY: test
+
+
+all: $(EXECUTABLE) test
+
+CXXFLAGS =-g $(INCLUDES)
+CXX=$(HIPCC)
+
+
+$(EXECUTABLE): $(OBJECTS)
+	$(HIPCC) $(OBJECTS) -o $@
+
+
+test: $(EXECUTABLE)
+	$(EXECUTABLE)
+
+
+clean:
+	rm -f $(EXECUTABLE)
+	rm -f $(OBJECTS)
+	rm -f $(HIP_PATH)/src/*.o

--- a/samples/2_Cookbook/5_2dshfl/CMakeLists.txt
+++ b/samples/2_Cookbook/5_2dshfl/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 - 2023 Advanced Micro Devices, Inc. All Rights Reserved.
+# Copyright (c) 2020 - 2021 Advanced Micro Devices, Inc. All Rights Reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -21,6 +21,13 @@
 project(2dshfl)
 
 cmake_minimum_required(VERSION 3.10)
+
+if (NOT DEFINED ROCM_PATH )
+     set ( ROCM_PATH "/opt/rocm"  CACHE STRING "Default ROCM installation directory." )
+endif ()
+
+# Search for rocm in common locations
+list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/hip ${ROCM_PATH})
 
 # Find hip
 find_package(hip)

--- a/samples/2_Cookbook/5_2dshfl/Makefile
+++ b/samples/2_Cookbook/5_2dshfl/Makefile
@@ -1,0 +1,64 @@
+# Copyright (c) 2016 - 2021 Advanced Micro Devices, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+ifeq ($(OS),Windows_NT)
+ $(error Makefile is not supported on windows platform. Please use cmake instead to build sample.)
+endif
+ROCM_PATH?= $(wildcard /opt/rocm/)
+HIP_PATH?= $(wildcard $(ROCM_PATH)/hip)
+ifeq (,$(HIP_PATH))
+	HIP_PATH=../../..
+endif
+
+ifeq (gfx701, $(findstring gfx701,$(HCC_AMDGPU_TARGET)))
+	$(error gfx701 is not a supported device for this sample)
+endif
+
+HIPCC=$(HIP_PATH)/bin/hipcc
+
+TARGET=hcc
+
+SOURCES = 2dshfl.cpp
+OBJECTS = $(SOURCES:.cpp=.o)
+INCLUDES  := -I../../common
+
+EXECUTABLE=./2dshfl
+
+.PHONY: test
+
+
+all: $(EXECUTABLE) test
+
+CXXFLAGS =-g $(INCLUDES)
+CXX=$(HIPCC)
+
+
+$(EXECUTABLE): $(OBJECTS)
+	$(HIPCC) $(OBJECTS) -o $@
+
+
+test: $(EXECUTABLE)
+	$(EXECUTABLE)
+
+
+clean:
+	rm -f $(EXECUTABLE)
+	rm -f $(OBJECTS)
+	rm -f $(HIP_PATH)/src/*.o
+

--- a/samples/2_Cookbook/6_dynamic_shared/CMakeLists.txt
+++ b/samples/2_Cookbook/6_dynamic_shared/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 - 2023 Advanced Micro Devices, Inc. All Rights Reserved.
+# Copyright (c) 2020 - 2021 Advanced Micro Devices, Inc. All Rights Reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,6 +23,14 @@ project(dynamic_shared)
 cmake_minimum_required(VERSION 3.10)
 
 include_directories(../../common)
+
+if (NOT DEFINED ROCM_PATH )
+     set ( ROCM_PATH "/opt/rocm"  CACHE STRING "Default ROCM installation directory." )
+endif ()
+
+# Search for rocm in common locations
+list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/hip ${ROCM_PATH})
+
 # Find hip
 find_package(hip)
 

--- a/samples/2_Cookbook/6_dynamic_shared/Makefile
+++ b/samples/2_Cookbook/6_dynamic_shared/Makefile
@@ -1,0 +1,60 @@
+# Copyright (c) 2016 - 2021 Advanced Micro Devices, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+ifeq ($(OS),Windows_NT)
+ $(error Makefile is not supported on windows platform. Please use cmake instead to build sample.)
+endif
+ROCM_PATH?= $(wildcard /opt/rocm/)
+HIP_PATH?= $(wildcard $(ROCM_PATH)/hip)
+ifeq (,$(HIP_PATH))
+	HIP_PATH=../../..
+endif
+
+HIPCC=$(HIP_PATH)/bin/hipcc
+
+TARGET=hcc
+
+SOURCES = dynamic_shared.cpp
+OBJECTS = $(SOURCES:.cpp=.o)
+INCLUDES  := -I../../common
+
+EXECUTABLE=./dynamic_shared
+
+.PHONY: test
+
+
+all: $(EXECUTABLE) test
+
+CXXFLAGS =-g $(INCLUDES)
+CXX=$(HIPCC)
+
+
+$(EXECUTABLE): $(OBJECTS)
+	$(HIPCC) $(OBJECTS) -o $@
+
+
+test: $(EXECUTABLE)
+	$(EXECUTABLE)
+
+
+clean:
+	rm -f $(EXECUTABLE)
+	rm -f $(OBJECTS)
+	rm -f $(HIP_PATH)/src/*.o
+

--- a/samples/2_Cookbook/7_streams/CMakeLists.txt
+++ b/samples/2_Cookbook/7_streams/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 - 2023 Advanced Micro Devices, Inc. All Rights Reserved.
+# Copyright (c) 2020 - 2021 Advanced Micro Devices, Inc. All Rights Reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -21,6 +21,13 @@
 project(stream)
 
 cmake_minimum_required(VERSION 3.10)
+
+if (NOT DEFINED ROCM_PATH )
+     set ( ROCM_PATH "/opt/rocm"  CACHE STRING "Default ROCM installation directory." )
+endif ()
+
+# Search for rocm in common locations
+list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/hip ${ROCM_PATH})
 
 # Find hip
 find_package(hip)

--- a/samples/2_Cookbook/7_streams/Makefile
+++ b/samples/2_Cookbook/7_streams/Makefile
@@ -1,0 +1,60 @@
+# Copyright (c) 2016 - 2021 Advanced Micro Devices, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+ifeq ($(OS),Windows_NT)
+ $(error Makefile is not supported on windows platform. Please use cmake instead to build sample.)
+endif
+ROCM_PATH?= $(wildcard /opt/rocm/)
+HIP_PATH?= $(wildcard $(ROCM_PATH)/hip)
+ifeq (,$(HIP_PATH))
+	HIP_PATH=../../..
+endif
+
+HIPCC=$(HIP_PATH)/bin/hipcc
+
+TARGET=hcc
+
+SOURCES = stream.cpp
+OBJECTS = $(SOURCES:.cpp=.o)
+INCLUDES  := -I../../common
+
+EXECUTABLE=./stream
+
+.PHONY: test
+
+
+all: $(EXECUTABLE) test
+
+CXXFLAGS =-g $(INCLUDES)
+CXX=$(HIPCC)
+
+
+$(EXECUTABLE): $(OBJECTS)
+	$(HIPCC) $(OBJECTS) -o $@
+
+
+test: $(EXECUTABLE)
+	$(EXECUTABLE)
+
+
+clean:
+	rm -f $(EXECUTABLE)
+	rm -f $(OBJECTS)
+	rm -f $(HIP_PATH)/src/*.o
+

--- a/samples/2_Cookbook/8_peer2peer/CMakeLists.txt
+++ b/samples/2_Cookbook/8_peer2peer/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 - 2023 Advanced Micro Devices, Inc. All Rights Reserved.
+# Copyright (c) 2020 - 2021 Advanced Micro Devices, Inc. All Rights Reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -21,6 +21,13 @@
 project(peer2peer)
 
 cmake_minimum_required(VERSION 3.10)
+
+if (NOT DEFINED ROCM_PATH )
+     set ( ROCM_PATH "/opt/rocm"  CACHE STRING "Default ROCM installation directory." )
+endif ()
+
+# Search for rocm in common locations
+list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/hip ${ROCM_PATH})
 
 # Find hip
 find_package(hip)

--- a/samples/2_Cookbook/8_peer2peer/Makefile
+++ b/samples/2_Cookbook/8_peer2peer/Makefile
@@ -1,0 +1,59 @@
+# Copyright (c) 2016 - 2021 Advanced Micro Devices, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+ifeq ($(OS),Windows_NT)
+ $(error Makefile is not supported on windows platform. Please use cmake instead to build sample.)
+endif
+ROCM_PATH?= $(wildcard /opt/rocm/)
+HIP_PATH?= $(wildcard $(ROCM_PATH)/hip)
+ifeq (,$(HIP_PATH))
+	HIP_PATH=../../..
+endif
+
+HIPCC=$(HIP_PATH)/bin/hipcc
+
+TARGET=hcc
+
+SOURCES = peer2peer.cpp
+OBJECTS = $(SOURCES:.cpp=.o)
+
+EXECUTABLE=./peer2peer
+
+.PHONY: test
+
+
+all: $(EXECUTABLE) test
+
+CXXFLAGS =-g
+CXX=$(HIPCC)
+
+
+$(EXECUTABLE): $(OBJECTS)
+	$(HIPCC) $(OBJECTS) -o $@
+
+
+test: $(EXECUTABLE)
+	$(EXECUTABLE)
+
+
+clean:
+	rm -f $(EXECUTABLE)
+	rm -f $(OBJECTS)
+	rm -f $(HIP_PATH)/src/*.o
+

--- a/samples/2_Cookbook/9_unroll/CMakeLists.txt
+++ b/samples/2_Cookbook/9_unroll/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 - 2023 Advanced Micro Devices, Inc. All Rights Reserved.
+# Copyright (c) 2020 - 2021 Advanced Micro Devices, Inc. All Rights Reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -21,6 +21,13 @@
 project(unroll)
 
 cmake_minimum_required(VERSION 3.10)
+
+if (NOT DEFINED ROCM_PATH )
+     set ( ROCM_PATH "/opt/rocm"  CACHE STRING "Default ROCM installation directory." )
+endif ()
+
+# Search for rocm in common locations
+list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/hip ${ROCM_PATH})
 
 # Find hip
 find_package(hip)

--- a/samples/2_Cookbook/9_unroll/Makefile
+++ b/samples/2_Cookbook/9_unroll/Makefile
@@ -1,0 +1,63 @@
+# Copyright (c) 2017 - 2021 Advanced Micro Devices, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+ifeq ($(OS),Windows_NT)
+ $(error Makefile is not supported on windows platform. Please use cmake instead to build sample.)
+endif
+ROCM_PATH?= $(wildcard /opt/rocm/)
+HIP_PATH?= $(wildcard $(ROCM_PATH)/hip)
+ifeq (,$(HIP_PATH))
+	HIP_PATH=../../..
+endif
+
+ifeq (gfx701, $(findstring gfx701,$(HCC_AMDGPU_TARGET)))
+	$(error gfx701 is not a supported device for this sample)
+endif
+
+HIPCC=$(HIP_PATH)/bin/hipcc
+
+TARGET=hcc
+
+SOURCES = unroll.cpp
+OBJECTS = $(SOURCES:.cpp=.o)
+INCLUDES  := -I../../common
+
+EXECUTABLE=./unroll
+
+.PHONY: test
+
+
+all: $(EXECUTABLE) test
+
+CXXFLAGS =-g $(INCLUDES)
+CXX=$(HIPCC)
+
+
+$(EXECUTABLE): $(OBJECTS)
+	$(HIPCC) $(OBJECTS) -o $@
+
+
+test: $(EXECUTABLE)
+	$(EXECUTABLE)
+
+
+clean:
+	rm -f $(EXECUTABLE)
+	rm -f $(OBJECTS)
+	rm -f $(HIP_PATH)/src/*.o

--- a/samples/README.md
+++ b/samples/README.md
@@ -12,7 +12,6 @@ make
 
 
 2.CMakeLists.txt can support shared and static libs of hip-rocclr runtime.
-The same steps can be followed for both.
 
 To build a sample, run in the sample folder,
 
@@ -20,7 +19,15 @@ mkdir -p build && cd build
 
 rm -rf * (to clear up)
 
-cmake -DCMAKE_PREFIX_PATH=<path/to/rocm> -DHIP_CXX_COMPILER=<path/to/clang> ..
+a. to build with shared libs, run
+
+cmake ..
+
+make
+
+b. to build with static libs, run
+
+cmake -DCMAKE_PREFIX_PATH="<ROCM_PATH>/llvm/lib/cmake" ..
 
 Then run,
 


### PR DESCRIPTION
Reverts ROCm-Developer-Tools/hip-tests#363