### PR TITLE
SWDEV-415692 - Disable test Unit_Grid_Group_Sync_Positive_Basic

### DIFF
--- a/catch/hipTestMain/config/config_amd_linux_common.json
+++ b/catch/hipTestMain/config/config_amd_linux_common.json
@@ -130,6 +130,8 @@
 	   "Unit_hiprtc_test_hip_bfloat16",
 	   "Unit_RTC_LinkerAPI",
 	   "Unit_hiprtc_half_shuffle",
-	   "Unit_hiprtc_includepath"
+	   "Unit_hiprtc_includepath",
+	   "SWDEV-415692 hangs in MI200",
+	   "Unit_Grid_Group_Sync_Positive_Basic"
 	]
 }


### PR DESCRIPTION
- Test Unit_Grid_Group_Sync_Positive_Basic hangs in MI200
- Temporarily disable it until hang issue is fixed

Change-Id: I5e261f42db0f363e7b302296a8f424a0d30f5672