### PR TITLE
EXSWHTEC-384 - Coverage Tool and Test Plan update

### DIFF
--- a/catch/unit/cooperativeGrps/coalesced_tiled_groups_metagrp.cc
+++ b/catch/unit/cooperativeGrps/coalesced_tiled_groups_metagrp.cc
@@ -21,7 +21,7 @@ THE SOFTWARE.
 */
 #include <hip_test_common.hh>
 #include <hip/hip_cooperative_groups.h>
-#include <hip_test_defgroups.hh>
+ 
 
 /**
  * @addtogroup coalesced_group thread_block_tile

--- a/catch/unit/dynamicLoading/complex_loading_behavior.cc
+++ b/catch/unit/dynamicLoading/complex_loading_behavior.cc
@@ -18,7 +18,7 @@ THE SOFTWARE.
 */
 #include <hip_test_common.hh>
 #include <dlfcn.h>
-#include <hip_test_defgroups.hh>
+ 
 /**
 * @addtogroup hipLaunchKernelGGL hipLaunchCooperativeKernel
 * @{

--- a/catch/unit/dynamicLoading/hipApiDynamicLoad.cc
+++ b/catch/unit/dynamicLoading/hipApiDynamicLoad.cc
@@ -17,7 +17,7 @@ OUT OF OR INN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 #include <hip_test_common.hh>
-#include <hip_test_defgroups.hh>
+ 
 #include <stdio.h>
 #include <dlfcn.h>
 #include <vector>

--- a/catch/unit/event/hipEventCreateWithFlags.cc
+++ b/catch/unit/event/hipEventCreateWithFlags.cc
@@ -22,7 +22,7 @@ THE SOFTWARE.
 
 #include <hip_test_common.hh>
 #include <hip_test_kernels.hh>
-#include <hip_test_defgroups.hh>
+ 
 #include <stdlib.h>
 
 constexpr size_t buffer_size = (1024*1024);

--- a/catch/unit/g++/hipMalloc.cc
+++ b/catch/unit/g++/hipMalloc.cc
@@ -18,7 +18,7 @@
  * */
 
 #include <hip_test_common.hh>
-#include <hip_test_defgroups.hh>
+ 
 #include "hipMalloc.h"
 /**
  * @addtogroup hipMalloc hipMalloc

--- a/catch/unit/gcc/gccTest.cc
+++ b/catch/unit/gcc/gccTest.cc
@@ -18,7 +18,7 @@
  * */
 
 #include <hip_test_common.hh>
-#include <hip_test_defgroups.hh>
+ 
 extern "C" {
 #include "LaunchKernel.h"
 }

--- a/catch/unit/graph/hipGraphAddDependencies.cc
+++ b/catch/unit/graph/hipGraphAddDependencies.cc
@@ -20,7 +20,7 @@ THE SOFTWARE.
 #include <hip_test_common.hh>
 #include <hip_test_checkers.hh>
 #include <hip_test_kernels.hh>
-#include <hip_test_defgroups.hh>
+ 
 
 #include "graph_dependency_common.hh"
 

--- a/catch/unit/graph/hipGraphAddKernelNode.cc
+++ b/catch/unit/graph/hipGraphAddKernelNode.cc
@@ -21,7 +21,7 @@ THE SOFTWARE.
 #include <hip_test_common.hh>
 #include <hip_test_kernels.hh>
 #include <hip_test_checkers.hh>
-#include <hip_test_defgroups.hh>
+ 
 
 #define CODEOBJ_FILE "add_Kernel.code"
 #define KERNEL_NAME "Add"

--- a/catch/unit/graph/hipGraphAddMemcpyNodeFromSymbol.cc
+++ b/catch/unit/graph/hipGraphAddMemcpyNodeFromSymbol.cc
@@ -22,7 +22,7 @@ THE SOFTWARE.
 #include <functional>
 #include <vector>
 
-#include <hip_test_defgroups.hh>
+ 
 #include <hip_test_common.hh>
 #include <hip_test_checkers.hh>
 

--- a/catch/unit/graph/hipGraphAddMemcpyNodeToSymbol.cc
+++ b/catch/unit/graph/hipGraphAddMemcpyNodeToSymbol.cc
@@ -23,7 +23,7 @@ THE SOFTWARE.
 #include <functional>
 #include <vector>
 
-#include <hip_test_defgroups.hh>
+ 
 #include <hip_test_common.hh>
 #include <hip_test_checkers.hh>
 

--- a/catch/unit/graph/hipGraphAddMemsetNode.cc
+++ b/catch/unit/graph/hipGraphAddMemsetNode.cc
@@ -22,7 +22,7 @@ THE SOFTWARE.
 #include <functional>
 #include <vector>
 
-#include <hip_test_defgroups.hh>
+ 
 #include <hip_test_common.hh>
 #include <resource_guards.hh>
 #include <utils.hh>

--- a/catch/unit/graph/hipGraphExecMemcpyNodeSetParamsToSymbol.cc
+++ b/catch/unit/graph/hipGraphExecMemcpyNodeSetParamsToSymbol.cc
@@ -22,7 +22,7 @@ THE SOFTWARE.
 #include <functional>
 #include <vector>
 
-#include <hip_test_defgroups.hh>
+ 
 #include <hip_test_common.hh>
 #include <hip_test_checkers.hh>
 

--- a/catch/unit/graph/hipGraphExecMemsetNodeSetParams.cc
+++ b/catch/unit/graph/hipGraphExecMemsetNodeSetParams.cc
@@ -21,7 +21,7 @@ THE SOFTWARE.
 
 #include <functional>
 
-#include <hip_test_defgroups.hh>
+ 
 #include <hip_test_common.hh>
 
 #include "graph_memset_node_test_common.hh"

--- a/catch/unit/graph/hipGraphGetEdges.cc
+++ b/catch/unit/graph/hipGraphGetEdges.cc
@@ -20,7 +20,7 @@ THE SOFTWARE.
 #include <hip_test_common.hh>
 #include <hip_test_checkers.hh>
 #include <hip_test_kernels.hh>
-#include <hip_test_defgroups.hh>
+ 
 
 #include "graph_dependency_common.hh"
 

--- a/catch/unit/graph/hipGraphGetNodes.cc
+++ b/catch/unit/graph/hipGraphGetNodes.cc
@@ -22,7 +22,7 @@ THE SOFTWARE.
 #include <hip_test_common.hh>
 #include <hip_test_checkers.hh>
 #include <hip_test_kernels.hh>
-#include <hip_test_defgroups.hh>
+ 
 
 #include "graph_dependency_common.hh"
 

--- a/catch/unit/graph/hipGraphGetRootNodes.cc
+++ b/catch/unit/graph/hipGraphGetRootNodes.cc
@@ -22,7 +22,7 @@ THE SOFTWARE.
 #include <hip_test_common.hh>
 #include <hip_test_checkers.hh>
 #include <hip_test_kernels.hh>
-#include <hip_test_defgroups.hh>
+ 
 
 #include "graph_dependency_common.hh"
 

--- a/catch/unit/graph/hipGraphMemcpyNodeSetParamsFromSymbol.cc
+++ b/catch/unit/graph/hipGraphMemcpyNodeSetParamsFromSymbol.cc
@@ -22,7 +22,7 @@ THE SOFTWARE.
 #include <functional>
 #include <vector>
 
-#include <hip_test_defgroups.hh>
+ 
 #include <hip_test_common.hh>
 #include <hip_test_checkers.hh>
 

--- a/catch/unit/graph/hipGraphMemcpyNodeSetParamsToSymbol.cc
+++ b/catch/unit/graph/hipGraphMemcpyNodeSetParamsToSymbol.cc
@@ -22,7 +22,7 @@ THE SOFTWARE.
 #include <functional>
 #include <vector>
 
-#include <hip_test_defgroups.hh>
+ 
 #include <hip_test_common.hh>
 #include <hip_test_checkers.hh>
 

--- a/catch/unit/graph/hipGraphMemsetNodeGetParams.cc
+++ b/catch/unit/graph/hipGraphMemsetNodeGetParams.cc
@@ -19,7 +19,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-#include <hip_test_defgroups.hh>
+ 
 #include <hip_test_common.hh>
 #include <resource_guards.hh>
 

--- a/catch/unit/graph/hipGraphMemsetNodeSetParams.cc
+++ b/catch/unit/graph/hipGraphMemsetNodeSetParams.cc
@@ -21,7 +21,7 @@ THE SOFTWARE.
 
 #include <functional>
 
-#include <hip_test_defgroups.hh>
+ 
 #include <hip_test_common.hh>
 
 #include "graph_memset_node_test_common.hh"

--- a/catch/unit/graph/hipGraphNodeGetDependencies.cc
+++ b/catch/unit/graph/hipGraphNodeGetDependencies.cc
@@ -22,7 +22,7 @@ THE SOFTWARE.
 #include <hip_test_common.hh>
 #include <hip_test_checkers.hh>
 #include <hip_test_kernels.hh>
-#include <hip_test_defgroups.hh>
+ 
 
 #include "graph_dependency_common.hh"
 

--- a/catch/unit/graph/hipGraphNodeGetDependentNodes.cc
+++ b/catch/unit/graph/hipGraphNodeGetDependentNodes.cc
@@ -22,7 +22,7 @@ THE SOFTWARE.
 #include <hip_test_common.hh>
 #include <hip_test_checkers.hh>
 #include <hip_test_kernels.hh>
-#include <hip_test_defgroups.hh>
+ 
 
 #include "graph_dependency_common.hh"
 

--- a/catch/unit/graph/hipGraphRemoveDependencies.cc
+++ b/catch/unit/graph/hipGraphRemoveDependencies.cc
@@ -20,7 +20,7 @@ THE SOFTWARE.
 #include <hip_test_common.hh>
 #include <hip_test_checkers.hh>
 #include <hip_test_kernels.hh>
-#include <hip_test_defgroups.hh>
+ 
 
 #include "graph_dependency_common.hh"
 

--- a/catch/unit/graph/hipLaunchHostFunc.cc
+++ b/catch/unit/graph/hipLaunchHostFunc.cc
@@ -18,7 +18,7 @@ THE SOFTWARE.
 */
 #include <hip_test_common.hh>
 #include <hip_test_kernels.hh>
-#include <hip_test_defgroups.hh>
+ 
 
 #include "stream_capture_common.hh"
 

--- a/catch/unit/graph/hipStreamBeginCapture.cc
+++ b/catch/unit/graph/hipStreamBeginCapture.cc
@@ -19,7 +19,7 @@ THE SOFTWARE.
 
 #include <hip_test_common.hh>
 #include <hip_test_kernels.hh>
-#include <hip_test_defgroups.hh>
+ 
 #include "stream_capture_common.hh" // NOLINT
 
 #pragma clang diagnostic ignored "-Wunused-variable"

--- a/catch/unit/graph/hipStreamEndCapture.cc
+++ b/catch/unit/graph/hipStreamEndCapture.cc
@@ -19,7 +19,7 @@ THE SOFTWARE.
 
 #include <hip_test_common.hh>
 #include <hip_test_kernels.hh>
-#include <hip_test_defgroups.hh>
+ 
 
 #include "stream_capture_common.hh"
 

--- a/catch/unit/graph/hipStreamGetCaptureInfo.cc
+++ b/catch/unit/graph/hipStreamGetCaptureInfo.cc
@@ -18,7 +18,7 @@ THE SOFTWARE.
 */
 
 #include <hip_test_checkers.hh>
-#include <hip_test_defgroups.hh>
+ 
 #include <hip_test_kernels.hh>
 
 #include "stream_capture_common.hh"

--- a/catch/unit/graph/hipStreamGetCaptureInfo_v2.cc
+++ b/catch/unit/graph/hipStreamGetCaptureInfo_v2.cc
@@ -19,7 +19,7 @@ THE SOFTWARE.
 
 #include <hip_test_checkers.hh>
 #include <hip_test_kernels.hh>
-#include <hip_test_defgroups.hh>
+ 
 
 #include "stream_capture_common.hh"
 

--- a/catch/unit/graph/hipStreamIsCapturing.cc
+++ b/catch/unit/graph/hipStreamIsCapturing.cc
@@ -18,7 +18,7 @@ THE SOFTWARE.
 */
 
 #include <hip_test_common.hh>
-#include <hip_test_defgroups.hh>
+ 
 #include <hip_test_kernels.hh>
 
 #include "stream_capture_common.hh"

--- a/catch/unit/graph/hipStreamUpdateCaptureDependencies.cc
+++ b/catch/unit/graph/hipStreamUpdateCaptureDependencies.cc
@@ -20,7 +20,7 @@ THE SOFTWARE.
 #include <hip_test_checkers.hh>
 #include <hip_test_common.hh>
 #include <hip_test_kernels.hh>
-#include <hip_test_defgroups.hh>
+ 
 
 #include "stream_capture_common.hh"
 

--- a/catch/unit/graph/hipThreadExchangeStreamCaptureMode.cc
+++ b/catch/unit/graph/hipThreadExchangeStreamCaptureMode.cc
@@ -20,7 +20,7 @@ THE SOFTWARE.
 #include <hip_test_checkers.hh>
 #include <hip_test_common.hh>
 #include <hip_test_kernels.hh>
-#include <hip_test_defgroups.hh>
+ 
 
 #include "stream_capture_common.hh"
 

--- a/catch/unit/kernel/hipDynamicShared.cc
+++ b/catch/unit/kernel/hipDynamicShared.cc
@@ -20,7 +20,7 @@ THE SOFTWARE.
 #include <hip_test_kernels.hh>
 #include <hip_test_checkers.hh>
 #include <hip_test_common.hh>
-#include <hip_test_defgroups.hh>
+ 
 
 #pragma clang diagnostic ignored "-Wunused-parameter"
 

--- a/catch/unit/kernel/hipDynamicShared2.cc
+++ b/catch/unit/kernel/hipDynamicShared2.cc
@@ -20,7 +20,7 @@ THE SOFTWARE.
 #include <hip_test_kernels.hh>
 #include <hip_test_checkers.hh>
 #include <hip_test_common.hh>
-#include <hip_test_defgroups.hh>
+ 
 
 #define LEN  (16 * 1024)
 #define SIZE (LEN * sizeof(float))

--- a/catch/unit/kernel/hipEmptyKernel.cc
+++ b/catch/unit/kernel/hipEmptyKernel.cc
@@ -20,7 +20,7 @@ THE SOFTWARE.
 #include <hip_test_kernels.hh>
 #include <hip_test_checkers.hh>
 #include <hip_test_common.hh>
-#include <hip_test_defgroups.hh>
+ 
 
 #pragma clang diagnostic ignored "-Wunused-parameter"
 

--- a/catch/unit/kernel/hipExtLaunchKernelGGL.cc
+++ b/catch/unit/kernel/hipExtLaunchKernelGGL.cc
@@ -21,7 +21,7 @@ THE SOFTWARE.
 #include <hip_test_kernels.hh>
 #include <hip_test_checkers.hh>
 #include <hip_test_common.hh>
-#include <hip_test_defgroups.hh>
+ 
 #include "hip/hip_ext.h"
 
 static unsigned threadsPerBlock = 256;

--- a/catch/unit/kernel/hipGridLaunch.cc
+++ b/catch/unit/kernel/hipGridLaunch.cc
@@ -21,7 +21,7 @@ THE SOFTWARE.
 #include <hip_test_kernels.hh>
 #include <hip_test_checkers.hh>
 #include <hip_test_common.hh>
-#include <hip_test_defgroups.hh>
+ 
 
 static unsigned threadsPerBlock = 256;
 static unsigned blocksPerCU = 6;

--- a/catch/unit/kernel/hipLanguageExtensions.cc
+++ b/catch/unit/kernel/hipLanguageExtensions.cc
@@ -20,7 +20,7 @@ THE SOFTWARE.
 #include <hip_test_kernels.hh>
 #include <hip_test_common.hh>
 #include <hip_test_checkers.hh>
-#include <hip_test_defgroups.hh>
+ 
 #include <hip/math_functions.h>
 
 #pragma clang diagnostic ignored "-Wunused-variable"

--- a/catch/unit/kernel/hipLaunchParm.cc
+++ b/catch/unit/kernel/hipLaunchParm.cc
@@ -20,7 +20,7 @@ THE SOFTWARE.
 #include <hip_test_kernels.hh>
 #include <hip_test_checkers.hh>
 #include <hip_test_common.hh>
-#include <hip_test_defgroups.hh>
+ 
 #include <cstdint>
 
 #pragma clang diagnostic ignored "-Wunused-variable"

--- a/catch/unit/kernel/hipLaunchParmFunctor.cc
+++ b/catch/unit/kernel/hipLaunchParmFunctor.cc
@@ -20,7 +20,7 @@ THE SOFTWARE.
 #include <hip_test_kernels.hh>
 #include <hip_test_checkers.hh>
 #include <hip_test_common.hh>
-#include <hip_test_defgroups.hh>
+ 
 
 class HipFunctorTests {
  public:

--- a/catch/unit/kernel/hipPrintfKernel.cc
+++ b/catch/unit/kernel/hipPrintfKernel.cc
@@ -17,7 +17,7 @@ OUT OF OR INN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 #include <hip_test_common.hh>
-#include <hip_test_defgroups.hh>
+ 
 #include <cstring>
 #include "../kernel/printf_common.h"
 

--- a/catch/unit/kernel/hipShflTests.cc
+++ b/catch/unit/kernel/hipShflTests.cc
@@ -21,7 +21,7 @@ THE SOFTWARE.
 #include <hip_test_checkers.hh>
 #include <hip_test_common.hh>
 #include <hip/hip_fp16.h>
-#include <hip_test_defgroups.hh>
+ 
 
 #define WIDTH 4
 

--- a/catch/unit/kernel/hipShflUpDownTest.cc
+++ b/catch/unit/kernel/hipShflUpDownTest.cc
@@ -21,7 +21,7 @@ THE SOFTWARE.
 #include <hip_test_checkers.hh>
 #include <hip_test_common.hh>
 #include <hip/hip_fp16.h>
-#include <hip_test_defgroups.hh>
+ 
 
 const int size = 32;
 

--- a/catch/unit/kernel/hipTestConstant.cc
+++ b/catch/unit/kernel/hipTestConstant.cc
@@ -17,7 +17,7 @@ OUT OF OR INN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 #include <hip_test_common.hh>
-#include <hip_test_defgroups.hh>
+ 
 
 #define LEN 512
 #define SIZE 2048

--- a/catch/unit/kernel/hipTestGlobalVariable.cc
+++ b/catch/unit/kernel/hipTestGlobalVariable.cc
@@ -17,7 +17,7 @@ OUT OF OR INN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 #include <hip_test_common.hh>
-#include <hip_test_defgroups.hh>
+ 
 
 #define LEN 512
 #define SIZE 2048

--- a/catch/unit/kernel/hipTestMemKernel.cc
+++ b/catch/unit/kernel/hipTestMemKernel.cc
@@ -17,7 +17,7 @@ OUT OF OR INN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 #include <hip_test_common.hh>
-#include <hip_test_defgroups.hh>
+ 
 
 #define LEN8 8 * 4
 #define LEN9 9 * 4

--- a/catch/unit/kernel/launch_bounds.cc
+++ b/catch/unit/kernel/launch_bounds.cc
@@ -17,7 +17,7 @@ OUT OF OR INN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 #include <hip_test_common.hh>
-#include <hip_test_defgroups.hh>
+ 
 
 constexpr size_t N = 1024;
 int p_blockSize = 256;

--- a/catch/unit/memory/hipHostRegister.cc
+++ b/catch/unit/memory/hipHostRegister.cc
@@ -32,7 +32,7 @@ THE SOFTWARE.
 #include <hip_test_common.hh>
 #include <hip_test_helper.hh>
 #include <hip_test_process.hh>
-#include <hip_test_defgroups.hh>
+ 
 #include <utils.hh>
 
 #define OFFSET 128

--- a/catch/unit/memory/hipPointerGetAttributes.cc
+++ b/catch/unit/memory/hipPointerGetAttributes.cc
@@ -30,7 +30,7 @@ Following scenarios are verified for hipPointerGetAttributes API
 */
 #include <inttypes.h>
 #include <hip_test_common.hh>
-#include <hip_test_defgroups.hh>
+ 
 #ifdef __linux__
 #include <sys/mman.h>
 #endif

--- a/catch/unit/module/hipExtModuleLaunchKernel.cc
+++ b/catch/unit/module/hipExtModuleLaunchKernel.cc
@@ -44,7 +44,7 @@ THE SOFTWARE.
  */
 
 #include <hip_test_common.hh>
-#include <hip_test_defgroups.hh>
+ 
 #include <iostream>
 #include <fstream>
 #include "hip/hip_ext.h"

--- a/catch/unit/p2p/hipDeviceGetP2PAttribute.cc
+++ b/catch/unit/p2p/hipDeviceGetP2PAttribute.cc
@@ -23,7 +23,7 @@ THE SOFTWARE.
 #include "hip/hip_runtime_api.h"
 #include <hip_test_process.hh>
 #include <string>
-#include <hip_test_defgroups.hh>
+ 
 
 /**
  * @addtogroup hipDeviceGetP2PAttribute hipDeviceGetP2PAttribute

--- a/catch/unit/p2p/hipP2pLinkTypeAndHopFunc.cc
+++ b/catch/unit/p2p/hipP2pLinkTypeAndHopFunc.cc
@@ -21,7 +21,7 @@ THE SOFTWARE.
 #include <hip_test_kernels.hh>
 #include <hip_test_checkers.hh>
 #include <hip_test_common.hh>
-#include <hip_test_defgroups.hh>
+ 
 #ifdef __linux__
 #include <unistd.h>
 #include <sys/wait.h>

--- a/catch/unit/printf/printfFlagsNonHost.cc
+++ b/catch/unit/printf/printfFlagsNonHost.cc
@@ -18,7 +18,7 @@ THE SOFTWARE.
 
 #include <hip_test_common.hh>
 #include <hip_test_process.hh>
-#include <hip_test_defgroups.hh>
+ 
 
 /**
 * @addtogroup printf

--- a/catch/unit/printf/printfHost.cc
+++ b/catch/unit/printf/printfHost.cc
@@ -19,7 +19,7 @@
    THE SOFTWARE.
  */
 #include <hip_test_common.hh>
-#include <hip_test_defgroups.hh>
+ 
 
 // Kernel Function
 __global__ void run_printf(int *count) {

--- a/catch/unit/printf/printfNonHost.cc
+++ b/catch/unit/printf/printfNonHost.cc
@@ -19,7 +19,7 @@
    THE SOFTWARE.
  */
 #include <hip_test_common.hh>
-#include <hip_test_defgroups.hh>
+ 
 
 #define ITER_COUNT 61681
 #define KERNEL_ITERATIONS 15

--- a/catch/unit/printf/printfSpecifiersNonHost.cc
+++ b/catch/unit/printf/printfSpecifiersNonHost.cc
@@ -22,7 +22,7 @@ THE SOFTWARE.
 
 #include <hip_test_common.hh>
 #include <hip_test_process.hh>
-#include <hip_test_defgroups.hh>
+ 
 
 /**
 * @addtogroup printf

--- a/catch/unit/stream/hipStreamGetDevice.cc
+++ b/catch/unit/stream/hipStreamGetDevice.cc
@@ -20,7 +20,7 @@ THE SOFTWARE.
 #include <hip_test_kernels.hh>
 #include <hip_test_common.hh>
 #include <hip_test_checkers.hh>
-#include <hip_test_defgroups.hh>
+ 
 #define NUMBER_OF_THREADS 10
 static bool thread_results[NUMBER_OF_THREADS];
 

--- a/utils/coverage/device_api_list.txt
+++ b/utils/coverage/device_api_list.txt
@@ -512,6 +512,9 @@ Device vector types [
 ]
 
 Device surface functions [
+  __hipGetPixelAddr
+  __hipMapToNativeFloat4
+  __hipMapFromNativeFloat4
   surf1Dread
   surf1Dwrite
   surf2Dread
@@ -669,6 +672,7 @@ Device float16 functions [
   __hbgeu2
   __hbltu2
   __hbgtu2
+  __clamp_01
   __hadd
   __habs
   __hsub

--- a/utils/coverage/device_api_list.txt
+++ b/utils/coverage/device_api_list.txt
@@ -512,9 +512,6 @@ Device vector types [
 ]
 
 Device surface functions [
-  __hipGetPixelAddr
-  __hipMapToNativeFloat4
-  __hipMapFromNativeFloat4
   surf1Dread
   surf1Dwrite
   surf2Dread
@@ -672,7 +669,6 @@ Device float16 functions [
   __hbgeu2
   __hbltu2
   __hbgtu2
-  __clamp_01
   __hadd
   __habs
   __hsub
@@ -730,4 +726,10 @@ Device float16 functions [
   __hisinf2
   __hisnan2
   __hneg2
+]
+
+OpenGL Interop [
+  hipGLGetDevices
+  hipGraphicsGLRegisterBuffer
+  hipGraphicsGLRegisterImage
 ]

--- a/utils/coverage/hipAPICoverageUtils.cpp
+++ b/utils/coverage/hipAPICoverageUtils.cpp
@@ -201,6 +201,7 @@ std::vector<HipAPI> extractHipAPIs(std::string& hip_api_header_file,
   of code shall not be considered.
   */
   std::string hip_api_prefix{"hip"};
+  std::string hip_api_prefix_builtin{"__hip"};
   std::string group_definition{"@defgroup"};
   std::string add_group_definition{"@addtogroup"};
   std::string start_of_api_groups{"HIP API"};
@@ -291,7 +292,11 @@ std::vector<HipAPI> extractHipAPIs(std::string& hip_api_header_file,
       Remove all spaces if they exist in the parsed string, e.g.,
       hipError_t hipDeviceSetLimit ( enum hipLimit_t limit, size_t value );.
       */
-      std::string api_name{api_name_no_brackets.substr(api_name_no_brackets.rfind(hip_api_prefix))};
+      auto api_name_pos = api_name_no_brackets.rfind(hip_api_prefix_builtin);
+      if (api_name_pos == std::string::npos) {
+        api_name_pos = api_name_no_brackets.rfind(hip_api_prefix);
+      }
+      std::string api_name{api_name_no_brackets.substr(api_name_pos)};
       api_name.erase(std::remove(api_name.begin(), api_name.end(), ' '), api_name.end());
 
       if (!api_group_names_tracker.empty()) {

--- a/utils/coverage/hipAPICoverageUtils.cpp
+++ b/utils/coverage/hipAPICoverageUtils.cpp
@@ -47,6 +47,8 @@ void findAPICallInFile(HipAPI& hip_api, std::string test_module_file) {
   std::string api_member{"." + hip_api.getName() + "("};
   std::string api_newline{"  " + hip_api.getName() + "("};
   std::string api_templated{" " + hip_api.getName() + "<"};
+  std::string api_kernel_def_macro{"_KERNEL_DEF(" + hip_api.getName()};
+  std::string api_test_def_macro{"_TEST_DEF(" + hip_api.getName()};
 
   std::string api_restriction{hip_api.getFileRestriction()};
   bool found_restriction{false};
@@ -66,7 +68,9 @@ void findAPICallInFile(HipAPI& hip_api, std::string test_module_file) {
         (line.find(api_member) != std::string::npos) ||
         (line.find(api_newline) != std::string::npos) ||
         (line.find(hip_api.getName() + "(") == 0) ||
-        (line.find(api_templated) != std::string::npos)) {
+        (line.find(api_templated) != std::string::npos) ||
+        (line.find(api_kernel_def_macro) != std::string::npos) ||
+        (line.find(api_test_def_macro) != std::string::npos)) {
       if (api_restriction == "" || found_restriction) {
         hip_api.addFileOccurrence(FileOccurrence(test_module_file, line_number));
       }
@@ -135,6 +139,8 @@ void findAPITestCaseInFileByAPIName(HipAPI& hip_api, std::string test_module_fil
   std::string line;
 
   std::string test_case_definition{"TEST_CASE("};
+  std::string test_def_macro{"_TEST_DEF("};
+  std::string test_def_impl_macro{"_TEST_DEF_IMPL("};
   std::string test_case{"None"};
 
   while (std::getline(test_module_file_handler, line)) {
@@ -145,6 +151,14 @@ void findAPITestCaseInFileByAPIName(HipAPI& hip_api, std::string test_module_fil
       test_case = test_case.substr(0, test_case.find("\""));
       if (test_case.find("_" + hip_api.getName() + "_") != std::string::npos) {
         hip_api.addTestCase(TestCaseOccurrence{test_case, test_module_file, line_number});
+      }
+    } else if ((line.find(test_def_macro) != std::string::npos) ||
+               (line.find(test_def_impl_macro) != std::string::npos)) {
+      test_case = line.substr(line.find("(") + 1);
+      test_case = test_case.substr(0, test_case.find(","));
+      if (test_case == hip_api.getName() || test_case == hip_api.getName() + "_wrapper") {
+        hip_api.addTestCase(TestCaseOccurrence{"Unit_Device_" + test_case + "_Accuracy_Positive",
+                                               test_module_file, line_number});
       }
     }
   }

--- a/utils/coverage/mainCoverage.cpp
+++ b/utils/coverage/mainCoverage.cpp
@@ -47,6 +47,7 @@ int main(int argc, char** argv) {
   std::cout << "Number of detected HIP APIs from " << hip_api_header_file << ": " << hip_apis.size()
             << std::endl;
 
+  api_group_names.push_back("Runtime Compilation");
   std::vector<HipAPI> hip_rtc_apis{extractHipAPIs(hip_rtc_header_file, api_group_names, true)};
   std::cout << "Number of detected HIP APIs from " << hip_rtc_header_file << ": "
             << hip_rtc_apis.size() << std::endl;


### PR DESCRIPTION
- Update the Coverage Tool to encompass all math device function tests
- Remove hip_test_defgroups.hh includes from source files.