### PR TITLE
Fix cmake build error for square sample

### DIFF
--- a/samples/0_Intro/square/CMakeLists.txt
+++ b/samples/0_Intro/square/CMakeLists.txt
@@ -33,7 +33,7 @@ if(UNIX)
 endif()
 
 # create square.cpp
-execute_process(COMMAND sh -c "${CMAKE_PREFIX_PATH}/bin/hipify-perl \
+execute_process(COMMAND sh -c "${ROCM_PATH}/bin/hipify-perl \
          ${CMAKE_CURRENT_SOURCE_DIR}/square.cu > ${CMAKE_CURRENT_BINARY_DIR}/square.cpp")
 
 # Find hip


### PR DESCRIPTION
CMAKE_PREFIX_PATH is a list, so it includes a semicolon when using it to find the hipify-script, which splits the shell command into two separate commands, and therefore fails