### PR TITLE
Remove references to __hipGetPCH and HIP_ENABLE_PCH. They are no longer used.

### DIFF
--- a/samples/0_Intro/bit_extract/CMakeLists.txt
+++ b/samples/0_Intro/bit_extract/CMakeLists.txt
@@ -22,14 +22,6 @@ project(bit_extract)
 
 cmake_minimum_required(VERSION 3.10)
 
-if(NOT WIN32 AND NOT DEFINED __HIP_ENABLE_PCH)
-  set(__HIP_ENABLE_PCH ON CACHE BOOL "enable/disable pre-compiled hip headers")
-endif()
-
-if(${__HIP_ENABLE_PCH})
-  add_definitions(-D__HIP_ENABLE_PCH)
-endif()
-
 if(UNIX)
   if(NOT DEFINED ROCM_PATH)
     set(ROCM_PATH "/opt/rocm" CACHE STRING "Default ROCM installation directory.")

--- a/samples/0_Intro/bit_extract/bit_extract.cpp
+++ b/samples/0_Intro/bit_extract/bit_extract.cpp
@@ -45,20 +45,6 @@ int main(int argc, char* argv[]) {
     size_t N = 1000000;
     size_t Nbytes = N * sizeof(uint32_t);
 
-#ifdef __HIP_ENABLE_PCH
-    // Verify hip_pch.o
-    const char* pch = nullptr;
-    unsigned int size = 0;
-    __hipGetPCH(&pch, &size);
-    printf("pch size: %u\n", size);
-    if (size == 0) {
-        printf("__hipGetPCH failed!\n");
-        return -1;
-    } else {
-        printf("__hipGetPCH succeeded!\n");
-    }
-#endif
-
     int deviceId;
     checkHipErrors(hipGetDevice(&deviceId));
     hipDeviceProp_t props;


### PR DESCRIPTION
Related to PR compute/ec/clr/+/1184122 and https://github.com/ROCm/MIOpen/pull/3484