### PR TITLE
SWDEV-550216 - hipFree syncs the memory stream only and hence Sync us…

### DIFF
--- a/catch/unit/stream/hipMultiStream.cc
+++ b/catch/unit/stream/hipMultiStream.cc
@@ -50,8 +50,9 @@ TEST_CASE("Unit_hipMultiStream_sameDevice") {
     HIP_CHECK(hipMalloc(&data[i], NN * sizeof(float)));
     hipLaunchKernelGGL(kernel, dim3(1), dim3(1), 0, streams[i], data[i], xd, NN);
     HIP_CHECK(hipGetLastError());
-    hipLaunchKernelGGL(HIP_KERNEL_NAME(nKernel), dim3(1), dim3(1), 0, 0, yd);
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(nKernel), dim3(1), dim3(1), 0, streams[i], yd);
     HIP_CHECK(hipGetLastError());
+    HIP_CHECK(hipStreamSynchronize(streams[i]));
     HIP_CHECK(hipFree(data[i]));
     HIP_CHECK(hipStreamDestroy(streams[i]));
   }


### PR DESCRIPTION
…er stream before freeing memory & destorying stream.

## Associated JIRA ticket number/Github issue number
<!-- For example: "Closes #1234" or "Fixes SWDEV-123456" -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## What were the changes?

<!-- Please give a short summary of the change. -->

## Why are these changes needed?

<!-- Please explain the motivation behind the change and why this solves the given problem. -->

## Updated CHANGELOG?

<!-- Needed for Release updates for a ROCm release. -->

- [ ] Yes
- [ ] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [ ] No, Does not apply to this PR.

## Additional Checks

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally.
- [ ] Any dependent changes have been merged.
