### PR TITLE
SWDEV-541478 - fix Unit_TexObjectCreate_TypeMipmaped_IncompleteInit

### DIFF
--- a/catch/unit/texture/hipTexObjectCreate.cc
+++ b/catch/unit/texture/hipTexObjectCreate.cc
@@ -305,7 +305,7 @@ TEST_CASE("Unit_TexObjectCreate_TypeMipmaped_IncompleteInit") {
   SECTION("Array is nullptr") {
     res_desc.res.mipmap.hMipmappedArray = nullptr;
     HIP_CHECK_ERROR(hipTexObjectCreate(&tex_object, &res_desc, &tex_desc, nullptr),
-                    hipErrorInvalidValue);
+                    hipErrorInvalidChannelDescriptor);
   }
 
   HIP_CHECK(hipFreeMipmappedArray(mipmapped_array));


### PR DESCRIPTION
## Associated JIRA ticket number/Github issue number
<!-- For example: "Closes #1234" or "Fixes SWDEV-123456" -->
SWDEV-541478
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## What were the changes?

<!-- Please give a short summary of the change. -->

## Why are these changes needed?

<!-- Please explain the motivation behind the change and why this solves the given problem. -->

## Updated CHANGELOG?

<!-- Needed for Release updates for a ROCm release. -->

- [ ] Yes
- [ ] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [ ] No, Does not apply to this PR.

## Additional Checks

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally.
- [ ] Any dependent changes have been merged.
