### PR TITLE
SWDEV-548241 - Add missing destroy calls in graph tests

### DIFF
--- a/catch/unit/graph/hipGraph.cc
+++ b/catch/unit/graph/hipGraph.cc
@@ -99,6 +99,8 @@ static void hipWithoutGraphs(float* inputVec_h, float* inputVec_d,
     HIP_CHECK(hipMemcpyAsync(&result_h, result_d, sizeof(double),
                                                   hipMemcpyDefault, stream1));
     HIP_CHECK(hipStreamSynchronize(stream1));
+    HIP_CHECK(hipStreamSynchronize(stream2));
+    HIP_CHECK(hipStreamSynchronize(stream3));
   }
   auto stop = std::chrono::high_resolution_clock::now();
   auto result = std::chrono::duration<double, std::milli>(stop - start);

--- a/catch/unit/graph/hipGraphAddChildGraphNode.cc
+++ b/catch/unit/graph/hipGraphAddChildGraphNode.cc
@@ -116,6 +116,10 @@ TEST_CASE("Unit_hipGraphAddChildGraphNode_Negative") {
           nullptr, 10, childgraph1)
         == hipErrorInvalidValue);
   }
+
+  HIP_CHECK(hipGraphDestroy(graph));
+  HIP_CHECK(hipGraphDestroy(childgraph1));
+  HipTest::freeArrays<int>(A_d, B_d, nullptr, A_h, B_h, nullptr, false);
 }
 
 /*
@@ -232,7 +236,6 @@ TEST_CASE("Unit_hipGraphAddChildGraphNode_CloneChildGraph") {
   HipTest::initArrays<int>(&A_d, &B_d, nullptr, &A_h, &B_h, nullptr, N, false);
 
   HIP_CHECK(hipGraphCreate(&graph, 0));
-  HIP_CHECK(hipGraphCreate(&clonedgraph, 0));
   hipGraphNode_t memcpyH2D_A, memcpyH2D_B, childGraphNode1;
   hipStream_t streamForGraph;
   HIP_CHECK(hipStreamCreate(&streamForGraph));
@@ -268,6 +271,7 @@ TEST_CASE("Unit_hipGraphAddChildGraphNode_CloneChildGraph") {
   HIP_CHECK(hipGraphExecDestroy(graphExec));
   HIP_CHECK(hipGraphDestroy(childgraph1));
   HIP_CHECK(hipGraphDestroy(graph));
+  HIP_CHECK(hipGraphDestroy(clonedgraph));
   HIP_CHECK(hipStreamDestroy(streamForGraph));
 }
 

--- a/catch/unit/graph/hipGraphChildGraphNodeGetGraph.cc
+++ b/catch/unit/graph/hipGraphChildGraphNodeGetGraph.cc
@@ -159,5 +159,6 @@ TEST_CASE("Unit_hipGraphChildGraphNodeGetGraph_Negative") {
   }
 #endif
   HipTest::freeArrays(A_d, B_d, C_d, A_h, B_h, C_h, false);
+  HIP_CHECK(hipGraphDestroy(graph));
   HIP_CHECK(hipGraphDestroy(childgraph1));
 }

--- a/catch/unit/graph/hipGraphDestroyNode.cc
+++ b/catch/unit/graph/hipGraphDestroyNode.cc
@@ -86,6 +86,7 @@ TEST_CASE("Unit_hipGraphDestroyNode_BasicFunctionality") {
   HIP_CHECK(hipGraphAddMemsetNode(&memsetNode, graph, nullptr, 0,
                                                               &memsetParams));
   REQUIRE(hipGraphDestroyNode(memsetNode) == hipSuccess);
+  HIP_CHECK(hipGraphDestroy(graph));
   HIP_CHECK(hipFree(pOutBuff_d));
 }
 
@@ -209,7 +210,6 @@ TEST_CASE("Unit_hipGraphDestroyNode_Complx_ChkNumOfNodesNDep_ClonedGrph") {
   hipGraphNode_t kernelnode[NUM_OF_DUMMY_NODES];
   hipKernelNodeParams kernelNodeParams[NUM_OF_DUMMY_NODES];
   HIP_CHECK(hipGraphCreate(&graph, 0));
-  HIP_CHECK(hipGraphCreate(&clonedgraph, 0));
   // Create graph with no dependencies
   for (int i = 0; i < NUM_OF_DUMMY_NODES; i++) {
     void* kernelArgs[] = {nullptr};

--- a/catch/unit/graph/hipGraphExecGetFlags.cc
+++ b/catch/unit/graph/hipGraphExecGetFlags.cc
@@ -62,6 +62,7 @@ TEST_CASE("Unit_hipGraphExecGetFlags_Negative") {
       hipGraphInstantiateFlagAutoFreeOnLaunch));
   HIP_CHECK_ERROR(hipGraphExecGetFlags(nullptr, &flags),
                      hipErrorInvalidValue);
+  HIP_CHECK(hipGraphExecDestroy(graphExec));
   HIP_CHECK(hipGraphDestroy(graph));
 }
 
@@ -140,6 +141,7 @@ TEST_CASE("Unit_hipGraphExecGetFlags_positive") {
     REQUIRE(flags == hipGraphInstantiateFlagUseNodePriority);
   }
 #endif
+  HIP_CHECK(hipGraphExecDestroy(graphExec));
   HIP_CHECK(hipGraphDestroy(graph));
 }
 /**

--- a/catch/unit/graph/hipGraphExecMemcpyNodeSetParams.cc
+++ b/catch/unit/graph/hipGraphExecMemcpyNodeSetParams.cc
@@ -254,16 +254,14 @@ TEST_CASE("Unit_hipGraphExecMemcpyNodeSetParams_Negative_Changing_Memcpy_Directi
   hipGraphExec_t graph_exec = nullptr;
   HIP_CHECK(hipGraphInstantiate(&graph_exec, graph, nullptr, nullptr, 0));
 
-  const auto set_dir =  GENERATE(hipMemcpyHostToHost, hipMemcpyHostToDevice, hipMemcpyDeviceToHost,
+  const auto set_dir = GENERATE(hipMemcpyHostToHost, hipMemcpyHostToDevice, hipMemcpyDeviceToHost,
                                 hipMemcpyDeviceToDevice, hipMemcpyDefault);
-  if (dir == set_dir) {
-    HIP_CHECK(hipGraphExecDestroy(graph_exec));
-    HIP_CHECK(hipGraphDestroy(graph));
-    return;
+  if (dir != set_dir) {
+    params.kind = set_dir;
+    HIP_CHECK_ERROR(hipGraphExecMemcpyNodeSetParams(graph_exec, node, &params),
+                    hipErrorInvalidValue);
   }
 
-  params.kind = set_dir;
-  HIP_CHECK_ERROR(hipGraphExecMemcpyNodeSetParams(graph_exec, node, &params), hipErrorInvalidValue);
   HIP_CHECK(hipGraphExecDestroy(graph_exec));
   HIP_CHECK(hipGraphDestroy(graph));
   HIP_CHECK(hipHostFree(host));

--- a/catch/unit/graph/hipGraphExecMemcpyNodeSetParams1D.cc
+++ b/catch/unit/graph/hipGraphExecMemcpyNodeSetParams1D.cc
@@ -241,15 +241,11 @@ TEST_CASE("Unit_hipGraphExecMemcpyNodeSetParams1D_Negative_Changing_Memcpy_Direc
 
   const auto set_dir = GENERATE(hipMemcpyHostToHost, hipMemcpyHostToDevice, hipMemcpyDeviceToHost,
                                 hipMemcpyDeviceToDevice, hipMemcpyDefault);
-  if (dir == set_dir) {
-    HIP_CHECK(hipGraphExecDestroy(graph_exec));
-    HIP_CHECK(hipGraphDestroy(graph));
-    return;
+  if (dir != set_dir) {
+    HIP_CHECK_ERROR(
+        hipGraphExecMemcpyNodeSetParams1D(graph_exec, node, dst, src, sizeof(int), set_dir),
+        hipErrorInvalidValue);
   }
-
-  HIP_CHECK_ERROR(
-      hipGraphExecMemcpyNodeSetParams1D(graph_exec, node, dst, src, sizeof(int), set_dir),
-      hipErrorInvalidValue);
 
   HIP_CHECK(hipGraphExecDestroy(graph_exec));
   HIP_CHECK(hipGraphDestroy(graph));

--- a/catch/unit/graph/hipGraphExecUpdate.cc
+++ b/catch/unit/graph/hipGraphExecUpdate.cc
@@ -119,6 +119,7 @@ TEST_CASE("Unit_hipGraphExecUpdate_Negative_TypeChange") {
   HIP_CHECK(hipGraphDestroy(graph));
   HIP_CHECK(hipGraphDestroy(graph2));
   HIP_CHECK(hipStreamDestroy(streamForGraph));
+  HipTest::freeArrays<int>(A_d, nullptr, nullptr, A_h, nullptr, nullptr, false);
 }
 
 /**

--- a/catch/unit/graph/hipGraphGetNodes_old.cc
+++ b/catch/unit/graph/hipGraphGetNodes_old.cc
@@ -298,6 +298,7 @@ TEST_CASE("Unit_hipGraphGetNodes_ParamValidation") {
     HIP_CHECK(hipGraphCreate(&emptyGraph, 0));
     HIP_CHECK(hipGraphGetNodes(emptyGraph, nullptr, &numNodes));
     REQUIRE(numNodes == 0);
+    HIP_CHECK(hipGraphDestroy(emptyGraph));
   }
 
   SECTION("numNodes less than actual number of nodes") {

--- a/catch/unit/graph/hipGraphGetRootNodes_old.cc
+++ b/catch/unit/graph/hipGraphGetRootNodes_old.cc
@@ -327,6 +327,7 @@ TEST_CASE("Unit_hipGraphGetRootNodes_ParamValidation") {
     HIP_CHECK(hipGraphCreate(&emptyGraph, 0));
     HIP_CHECK(hipGraphGetRootNodes(emptyGraph, nullptr, &numRootNodes));
     REQUIRE(numRootNodes == 0);
+    HIP_CHECK(hipGraphDestroy(emptyGraph));
   }
 
   SECTION("numRootNodes less than actual number of nodes") {
@@ -402,7 +403,6 @@ TEST_CASE("Unit_hipGraphGetRootNodes_Complx_NumRootNodes_ClonedGrph") {
   hipGraphNode_t kernelnode[NUM_OF_DUMMY_NODES];
   hipKernelNodeParams kernelNodeParams[NUM_OF_DUMMY_NODES];
   HIP_CHECK(hipGraphCreate(&graph, 0));
-  HIP_CHECK(hipGraphCreate(&clonedgraph, 0));
   // Create graph with no dependencies
   for (int i = 0; i < NUM_OF_DUMMY_NODES; i++) {
     void* kernelArgs[] = {nullptr};

--- a/catch/unit/graph/hipGraphHostNodeSetParams.cc
+++ b/catch/unit/graph/hipGraphHostNodeSetParams.cc
@@ -160,6 +160,7 @@ TEST_CASE("Unit_hipGraphHostNodeSetParams_ClonedGraphWithHostNode") {
   HipTest::freeArrays<int>(A_d, nullptr, C_d, A_h, nullptr, C_h, false);
   HIP_CHECK(hipGraphExecDestroy(graphExec));
   HIP_CHECK(hipGraphDestroy(graph));
+  HIP_CHECK(hipGraphDestroy(clonedgraph));
   HIP_CHECK(hipStreamDestroy(streamForGraph));
 }
 

--- a/catch/unit/graph/hipGraphInstantiate.cc
+++ b/catch/unit/graph/hipGraphInstantiate.cc
@@ -75,6 +75,7 @@ TEST_CASE("Unit_hipGraphInstantiate_Negative") {
   SECTION("Pass pGraphExec as un-initialize") {
     ret = hipGraphInstantiate(&gExec, graph, nullptr, nullptr, 0);
     REQUIRE(hipSuccess == ret);
+    HIP_CHECK(hipGraphExecDestroy(gExec));
   }
   HIP_CHECK(hipGraphDestroy(graph));
 }

--- a/catch/unit/graph/hipGraphInstantiateWithFlags.cc
+++ b/catch/unit/graph/hipGraphInstantiateWithFlags.cc
@@ -77,6 +77,7 @@ TEST_CASE("Unit_hipGraphInstantiateWithFlags_Negative") {
     HIP_CHECK(hipGraphCreate(&graph, 0));
     REQUIRE(hipGraphInstantiateWithFlags(nullptr,
                                          graph, 0) == hipErrorInvalidValue);
+    HIP_CHECK(hipGraphDestroy(graph));
   }
 
   SECTION("Passing nullptr to graph") {
@@ -90,6 +91,7 @@ TEST_CASE("Unit_hipGraphInstantiateWithFlags_Negative") {
     HIP_CHECK(hipGraphCreate(&graph, 0));
     hipGraphExec_t graphExec;
     REQUIRE(hipGraphInstantiateWithFlags(&graphExec, graph, 10) != hipSuccess);
+    HIP_CHECK(hipGraphDestroy(graph));
   }
 }
 /*

--- a/catch/unit/graph/hipGraphInstantiateWithParams.cc
+++ b/catch/unit/graph/hipGraphInstantiateWithParams.cc
@@ -58,6 +58,7 @@ TEST_CASE("Unit_hipGraphInstantiateWithParams_Negative") {
     HIP_CHECK(hipGraphCreate(&graph, 0));
     REQUIRE(hipGraphInstantiateWithParams(nullptr,
                                        graph, &params) == hipErrorInvalidValue);
+    HIP_CHECK(hipGraphDestroy(graph));
   }
 
   SECTION("Passing nullptr to graph") {
@@ -73,6 +74,7 @@ TEST_CASE("Unit_hipGraphInstantiateWithParams_Negative") {
     hipGraphExec_t graphExec;
     REQUIRE(hipGraphInstantiateWithParams(&graphExec,
                                        graph, nullptr) == hipErrorInvalidValue);
+    HIP_CHECK(hipGraphDestroy(graph));
   }
 
   SECTION("Passing invalid flag") {
@@ -84,6 +86,7 @@ TEST_CASE("Unit_hipGraphInstantiateWithParams_Negative") {
     REQUIRE(hipGraphInstantiateWithParams(&graphExec,
                                        graph, &params) == hipErrorInvalidValue);
     REQUIRE(params.result_out == hipGraphInstantiateError);
+    HIP_CHECK(hipGraphDestroy(graph));
   }
 }
 
@@ -203,19 +206,17 @@ void GraphInstantiateWithParams_StreamCapture() {
   HIP_CHECK(hipMalloc(&C_d, Nbytes));
   REQUIRE(A_d != nullptr);
   REQUIRE(C_d != nullptr);
-  HIP_CHECK(hipGraphCreate(&graph, 0));
-
 
   HIP_CHECK(hipStreamCreate(&stream));
+  HIP_CHECK(hipStreamBeginCapture(stream, hipStreamCaptureModeGlobal));
+
+  HIP_CHECK(hipMemcpyAsync(A_d, A_h, Nbytes, hipMemcpyHostToDevice, stream));
+  HIP_CHECK(hipMemsetAsync(C_d, 0, Nbytes, stream));
+
   constexpr unsigned blocks = 512;
   constexpr unsigned threadsPerBlock = 256;
-
-  HIP_CHECK(hipStreamBeginCapture(stream, hipStreamCaptureModeGlobal));
-  HIP_CHECK(hipMemcpyAsync(A_d, A_h, Nbytes, hipMemcpyHostToDevice, stream));
-
-  HIP_CHECK(hipMemsetAsync(C_d, 0, Nbytes, stream));
-  hipLaunchKernelGGL(HipTest::vector_square, dim3(blocks),
-                              dim3(threadsPerBlock), 0, stream, A_d, C_d, N);
+  hipLaunchKernelGGL(HipTest::vector_square, dim3(blocks), dim3(threadsPerBlock), 0, stream, A_d,
+                     C_d, N);
   HIP_CHECK(hipMemcpyAsync(C_h, C_d, Nbytes, hipMemcpyDeviceToHost, stream));
 
   HIP_CHECK(hipStreamEndCapture(stream, &graph));
@@ -282,7 +283,7 @@ TEST_CASE("Unit_hipGraphInstantiateWithParams_DependencyGraph") {
 * - HIP_VERSION >= 6.2
 */
 TEST_CASE("Unit_hipGraphInstantiateWithParams_StreamCapture") {
-      GraphInstantiateWithParams_StreamCapture();
+  GraphInstantiateWithParams_StreamCapture();
 }
 
 

--- a/catch/unit/graph/hipGraphNodeFindInClone.cc
+++ b/catch/unit/graph/hipGraphNodeFindInClone.cc
@@ -190,8 +190,6 @@ void hipGraphNodeFindInClone_Func(bool ModifyOrigGraph = false) {
   HIP_CHECK(hipGraphAddDependencies(graph, &kernel_vecAdd, &memcpyD2H_C, 1));
 
   if (ModifyOrigGraph) {
-    // Cloned the graph
-    HIP_CHECK(hipGraphClone(&clonedgraph, graph));
     // Modify Original graph by adding new dependency
     HIP_CHECK(hipGraphAddMemcpyNode1D(&memcpyD2D_C, graph, nullptr, 0, C_d, B_d,
                                       Nbytes, hipMemcpyDeviceToHost));
@@ -274,8 +272,12 @@ void hipGraphNodeFindInClone_DoubleClone(bool ModifyOrigGraph = false) {
         hipGraphAddDependencies(graph, &kernel_vecAdd, &memcpyD2H_C_new, 1));
   }
   hipGraphNode_t clonedgraphnode;
-  REQUIRE(hipGraphNodeFindInClone(&clonedgraphnode, memcpyH2D_A,
-                                  clonedgraph_1) == hipErrorInvalidValue);
+  REQUIRE(hipGraphNodeFindInClone(&clonedgraphnode, memcpyH2D_A, clonedgraph_1) ==
+          hipErrorInvalidValue);
+  HIP_CHECK(hipGraphDestroy(clonedgraph_1));
+  HIP_CHECK(hipGraphDestroy(clonedgraph));
+  HIP_CHECK(hipGraphDestroy(graph));
+  HipTest::freeArrays(A_d, B_d, C_d, A_h, B_h, C_h, false);
 }
 /**
  * Test Description

--- a/catch/unit/graph/hipGraphNodeGetType.cc
+++ b/catch/unit/graph/hipGraphNodeGetType.cc
@@ -74,6 +74,7 @@ TEST_CASE("Unit_hipGraphNodeGetType_Negative") {
     HIP_CHECK(hipGraphCreate(&graph, 0));
     HIP_CHECK(hipGraphAddEmptyNode(&memcpyNode, graph, nullptr , 0));
     REQUIRE(hipGraphNodeGetType(memcpyNode, nullptr) == hipErrorInvalidValue);
+    HIP_CHECK(hipGraphDestroy(graph));
   }
 
   SECTION("Pass invalid node") {
@@ -116,8 +117,11 @@ TEST_CASE("Unit_hipGraphNodeGetType_Functional") {
     HIP_CHECK(hipGraphNodeGetType(waiteventNode, &nodeType));
     REQUIRE(nodeType == hipGraphNodeTypeEmpty);
   }
+
+  HIP_CHECK(hipGraphDestroy(graph));
   HIP_CHECK(hipStreamDestroy(stream));
   HIP_CHECK(hipEventDestroy(event));
+  HipTest::freeArrays(A_d, B_d, C_d, A_h, B_h, C_h, false);
 }
 /**
  * Functional Test for hipGraphNodeGetType API
@@ -419,6 +423,7 @@ TEST_CASE("Unit_hipGraphNodeGetType_NodeTypeOfClonedGraph_NodeTypeInThread") {
   SECTION("Cloned Graph Node Type") {
     HIP_CHECK(hipGraphClone(&clonedGraph, graph));
     ChkNodeType(clonedGraph, &numNode);
+    HIP_CHECK(hipGraphDestroy(clonedGraph));
   }
   // Thread
   SECTION("Node Type In The Thread") {
@@ -543,6 +548,7 @@ TEST_CASE("Unit_hipGraphNodeGetType_NodeTypeOfChildGraph") {
   HIP_CHECK(hipGraphChildGraphNodeGetGraph(childGraphNode, &getGraph));
   ChkNodeType(getGraph, &numNodeChild);
 
+  HIP_CHECK(hipStreamSynchronize(stream2));
   HIP_CHECK(hipStreamDestroy(stream1));
   HIP_CHECK(hipEventDestroy(event1));
   HIP_CHECK(hipStreamDestroy(stream2));
@@ -676,6 +682,7 @@ TEST_CASE("Unit_hipGraphNodeGetType_ClonedGraph_InThread_WithDependencies") {
   SECTION("Cloned Graph Node Type") {
     HIP_CHECK(hipGraphClone(&clonedGraph, graph));
     ChkNodeTypeWithDependency(clonedGraph, Parent);
+    HIP_CHECK(hipGraphDestroy(clonedGraph));
   }
   // Thread
   SECTION("Node Type In The Thread") {

--- a/catch/unit/graph/hipGraphNodeSetParams.cc
+++ b/catch/unit/graph/hipGraphNodeSetParams.cc
@@ -90,6 +90,8 @@ TEST_CASE("Unit_hipGraphNodeSetParams_Negative_Parameters") {
 
   HIP_CHECK(hipGraphExecDestroy(graphExec));
   HIP_CHECK(hipGraphDestroy(graph));
+  HIP_CHECK(hipFree(A_d));
+  free(A_h);
 }
 
 /**

--- a/catch/unit/graph/hipGraphRemoveDependencies_old.cc
+++ b/catch/unit/graph/hipGraphRemoveDependencies_old.cc
@@ -270,6 +270,9 @@ TEST_CASE("Unit_hipGraphRemoveDependencies_Func_StrmCapture") {
   HIP_CHECK(hipStreamDestroy(stream1));
   HIP_CHECK(hipStreamDestroy(stream2));
   HIP_CHECK(hipStreamDestroy(stream3));
+  HIP_CHECK(hipEventDestroy(forkStreamEvent));
+  HIP_CHECK(hipEventDestroy(memsetEvent1));
+  HIP_CHECK(hipEventDestroy(memsetEvent2));
   HipTest::freeArrays(A_d, B_d, C_d, A_h, B_h, C_h, false);
 }
 

--- a/catch/unit/graph/hipStreamBeginCapture.cc
+++ b/catch/unit/graph/hipStreamBeginCapture.cc
@@ -20,6 +20,7 @@ THE SOFTWARE.
 #include <hip_test_common.hh>
 #include <hip_test_kernels.hh>
 
+#include "graph_dependency_common.hh"
 #include "stream_capture_common.hh" // NOLINT
 
 #pragma clang diagnostic ignored "-Wunused-variable"
@@ -195,6 +196,9 @@ TEST_CASE("Unit_hipStreamBeginCapture_Negative_Parameters") {
     HIP_CHECK(hipStreamBeginCapture(stream, hipStreamCaptureModeGlobal));
     HIP_CHECK_ERROR(hipStreamBeginCapture(stream, hipStreamCaptureModeGlobal),
                     hipErrorIllegalState);
+    hipGraph_t graph;
+    HIP_CHECK(hipStreamEndCapture(stream, &graph));
+    HIP_CHECK(hipGraphDestroy(graph));
   }
   SECTION("Creating hipStream with invalid mode") {
     HIP_CHECK_ERROR(hipStreamBeginCapture(stream, hipStreamCaptureMode(-1)), hipErrorInvalidValue);
@@ -315,6 +319,7 @@ static void colligatedStrmCapture(const hipStream_t& stream1, const hipStream_t&
   HIP_CHECK(hipGraphExecDestroy(graphExec1));
   HIP_CHECK(hipGraphDestroy(graph2));
   HIP_CHECK(hipGraphDestroy(graph1));
+  HIP_CHECK(hipEventDestroy(event));
 }
 
 /* Local function for colligated stream capture functionality
@@ -653,6 +658,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_Positive_Multiplestrms") {
     REQUIRE(numNodes1 == 1);
     REQUIRE(numNodes2 == 1);
     REQUIRE(numNodes3 == 1);
+    HIP_CHECK(hipEventDestroy(event));
   }
 
   for (int i = 0; i < 3; i++) {
@@ -754,6 +760,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_Negative_DetectingInvalidCapture") {
   HIP_CHECK_ERROR(hipStreamBeginCapture(streams[1], hipStreamCaptureModeGlobal),
                   hipErrorIllegalState);
   HIP_CHECK(hipStreamEndCapture(streams[0], &graph));
+  HIP_CHECK(hipGraphDestroy(graph));
 }
 
 /**
@@ -846,6 +853,9 @@ TEST_CASE("Unit_hipStreamBeginCapture_Negative_CheckingSyncDuringCapture") {
     HIP_CHECK(hipEventRecord(e, stream));
     HIP_CHECK_ERROR(hipEventQuery(e), hipErrorCapturedEvent);
   }
+
+  hipGraph_t graph;
+  HIP_CHECK_ERROR(hipStreamEndCapture(stream, &graph), hipErrorStreamCaptureInvalidated);
 }
 
 /**
@@ -880,21 +890,40 @@ TEST_CASE("Unit_hipStreamBeginCapture_Negative_Concurrent_CheckingSyncDuringCapt
   HIP_CHECK(hipStreamBeginCapture(stream, captureMode));
   SECTION("Synchronize stream during capture") {
     streamSync func;
+    hipGraph_t gr;
     hipError_t expected = hipSuccess;
-    if (captureMode == hipStreamCaptureModeGlobal) expected = hipErrorStreamCaptureUnsupported;
+    hipError_t capture_err = hipSuccess;
+    if (captureMode == hipStreamCaptureModeGlobal) {
+      expected = hipErrorStreamCaptureUnsupported;
+      capture_err = hipErrorStreamCaptureInvalidated;
+    }
 
     std::thread t(std::ref(func), concurrent_stream);
     t.join();
     REQUIRE(func.result_status == expected);
+    HIP_CHECK_ERROR(hipStreamEndCapture(stream, &gr), capture_err);
+    if (capture_err == hipSuccess) {
+      HIP_CHECK(hipGraphDestroy(gr));
+    }
   }
   SECTION("Query stream during capture") {
     streamQuery func;
+    hipGraph_t gr;
     hipError_t expected = hipSuccess;
-    if (captureMode == hipStreamCaptureModeGlobal) expected = hipErrorStreamCaptureUnsupported;
+    hipError_t capture_err = hipSuccess;
+    if (captureMode == hipStreamCaptureModeGlobal) {
+      expected = hipErrorStreamCaptureUnsupported;
+      capture_err = hipErrorStreamCaptureInvalidated;
+    }
 
     std::thread t(std::ref(func), concurrent_stream);
     t.join();
     REQUIRE(func.result_status == expected);
+
+    HIP_CHECK_ERROR(hipStreamEndCapture(stream, &gr), capture_err);
+    if (capture_err == hipSuccess) {
+      HIP_CHECK(hipGraphDestroy(gr));
+    }
   }
   SECTION("Synchronize device during capture") {
     deviceSync func;
@@ -903,6 +932,8 @@ TEST_CASE("Unit_hipStreamBeginCapture_Negative_Concurrent_CheckingSyncDuringCapt
     std::thread t(std::ref(func));
     t.join();
     REQUIRE(func.result_status == expected);
+    hipGraph_t gr;
+    HIP_CHECK_ERROR(hipStreamEndCapture(stream, &gr), hipErrorStreamCaptureInvalidated);
   }
   SECTION("Synchronize event during capture") {
     eventSync func;
@@ -911,6 +942,9 @@ TEST_CASE("Unit_hipStreamBeginCapture_Negative_Concurrent_CheckingSyncDuringCapt
     std::thread t(std::ref(func), e);
     t.join();
     REQUIRE(func.result_status == expected);
+    hipGraph_t gr;
+    HIP_CHECK(hipStreamEndCapture(stream, &gr));
+    HIP_CHECK(hipGraphDestroy(gr));
   }
   SECTION("Query for an event during capture") {
     eventQuery func;
@@ -919,6 +953,9 @@ TEST_CASE("Unit_hipStreamBeginCapture_Negative_Concurrent_CheckingSyncDuringCapt
     std::thread t(std::ref(func), e);
     t.join();
     REQUIRE(func.result_status == expected);
+    hipGraph_t gr;
+    HIP_CHECK(hipStreamEndCapture(stream, &gr));
+    HIP_CHECK(hipGraphDestroy(gr));
   }
 }
 
@@ -961,6 +998,9 @@ TEST_CASE("Unit_hipStreamBeginCapture_Negative_UnsafeCallsDuringCapture") {
   SECTION("hipMemset during capture") {
     HIP_CHECK_ERROR(hipMemset(devMem.ptr(), 0, sizeof(int)), hipErrorStreamCaptureImplicit);
   }
+
+  hipGraph_t graph;
+  HIP_CHECK_ERROR(hipStreamEndCapture(stream, &graph), hipErrorStreamCaptureInvalidated);
 }
 
 /**
@@ -996,6 +1036,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_Negative_EndingCapwhenCapInProg") {
     HIP_CHECK(hipStreamWaitEvent(stream2, e, 0));
     dummyKernel<<<1, 1, 0, stream2>>>();
     HIP_CHECK_ERROR(hipStreamEndCapture(stream1, &graph), hipErrorStreamCaptureUnjoined);
+    HIP_CHECK(hipEventDestroy(e));
   }
   SECTION("End strm capture when forked strm still has operations") {
     EventsGuard events_guard(2);
@@ -1524,6 +1565,8 @@ TEST_CASE("Unit_hipStreamBeginCapture_StreamSync_OngoingCapture_MThread") {
                              stream[1]));
     error = hipStreamSynchronize(stream[1]);
     REQUIRE(error == hipErrorStreamCaptureUnsupported);
+    hipGraph_t graph;
+    HIP_CHECK_ERROR(hipStreamEndCapture(stream[0], &graph), hipErrorStreamCaptureInvalidated);
   }
   SECTION("Capture Flag = hipStreamCaptureModeThreadLocal Single Threaded") {
     StreamsGuard stream(2);
@@ -1535,6 +1578,8 @@ TEST_CASE("Unit_hipStreamBeginCapture_StreamSync_OngoingCapture_MThread") {
                              stream[1]));
     error = hipStreamSynchronize(stream[1]);
     REQUIRE(error == hipErrorStreamCaptureUnsupported);
+    hipGraph_t graph;
+    HIP_CHECK_ERROR(hipStreamEndCapture(stream[0], &graph), hipErrorStreamCaptureInvalidated);
   }
   SECTION("Capture Flag = hipStreamCaptureModeGlobal Multithreaded") {
     captureStrmThread(&graph, Ah.host_ptr(), Ad.ptr(), Bh.host_ptr(), Bd.ptr(), BLOCKSIZE, GRIDSIZE,

--- a/catch/unit/graph/hipStreamBeginCaptureToGraph.cc
+++ b/catch/unit/graph/hipStreamBeginCaptureToGraph.cc
@@ -969,7 +969,6 @@ TEST_CASE("Unit_hipStreamBeginCaptureToGraph_StateTesting") {
   HIP_CHECK(hipStreamCreate(&stream2));
   HIP_CHECK(hipEventCreate(&e));
   hipStreamCaptureStatus captureStatus = hipStreamCaptureStatusNone;
-  HIP_CHECK(hipGraphCreate(&graph, 0));
   HIP_CHECK(hipStreamIsCapturing(stream1, &captureStatus));
   REQUIRE(captureStatus == hipStreamCaptureStatusNone);
   HIP_CHECK(hipStreamBeginCaptureToGraph(stream1, graph, nullptr, nullptr, 0,
@@ -1072,6 +1071,7 @@ TEST_CASE("Unit_hipStreamBeginCaptureToGraph_EndingWhileCaptureInProgress") {
               stream1));
     REQUIRE(hipSuccess == hipStreamEndCapture(stream1, &graph));
     HIP_CHECK(hipEventDestroy(e));
+    HIP_CHECK(hipGraphDestroy(graph));
   }
 
   SECTION("End strm capture when forked strm still has operations") {
@@ -1215,6 +1215,7 @@ static void threadCaptureStart(hipStream_t *streamCapt,
                            *streamFork));
   HIP_CHECK(hipEventRecord(e, *streamFork));
   HIP_CHECK(hipStreamWaitEvent(*streamCapt, e, 0));
+  HIP_CHECK(hipEventDestroy(e));
 }
 
 TEST_CASE("Unit_hipStreamBeginCaptureToGraph_CapturePartialInThreads") {

--- a/catch/unit/graph/hipStreamBeginCapture_old.cc
+++ b/catch/unit/graph/hipStreamBeginCapture_old.cc
@@ -297,6 +297,9 @@ TEST_CASE("Unit_hipStreamBeginCapture_Negative") {
     HIP_CHECK(hipStreamBeginCapture(stream, hipStreamCaptureModeGlobal));
     ret = hipStreamBeginCapture(stream, hipStreamCaptureModeGlobal);
     REQUIRE(hipErrorIllegalState == ret);
+    hipGraph_t graph;
+    HIP_CHECK(hipStreamEndCapture(stream, &graph));
+    HIP_CHECK(hipGraphDestroy(graph));
   }
   SECTION("Creating hipStream with invalid mode") {
     ret = hipStreamBeginCapture(stream, hipStreamCaptureMode(-1));
@@ -316,6 +319,15 @@ TEST_CASE("Unit_hipStreamBeginCapture_Basic") {
 
   HIP_CHECK(hipStreamCreate(&s3));
   HIP_CHECK(hipStreamBeginCapture(s3, hipStreamCaptureModeRelaxed));
+
+  hipGraph_t g1, g2, g3;
+  HIP_CHECK(hipStreamEndCapture(s1, &g1));
+  HIP_CHECK(hipStreamEndCapture(s2, &g2));
+  HIP_CHECK(hipStreamEndCapture(s3, &g3));
+
+  HIP_CHECK(hipGraphDestroy(g1));
+  HIP_CHECK(hipGraphDestroy(g2));
+  HIP_CHECK(hipGraphDestroy(g3));
 
   HIP_CHECK(hipStreamDestroy(s1));
   HIP_CHECK(hipStreamDestroy(s2));
@@ -669,6 +681,9 @@ TEST_CASE("Unit_hipStreamBeginCapture_multiplestrms") {
     REQUIRE(numNodes3 == 1);
     HIP_CHECK(hipEventDestroy(event2));
     HIP_CHECK(hipEventDestroy(event1));
+    HIP_CHECK(hipGraphDestroy(graph1));
+    HIP_CHECK(hipGraphDestroy(graph2));
+    HIP_CHECK(hipGraphDestroy(graph3));
   }
   SECTION("Capture Multiple stream with single event") {
     hipEvent_t event1;
@@ -692,6 +707,9 @@ TEST_CASE("Unit_hipStreamBeginCapture_multiplestrms") {
     REQUIRE(numNodes2 == 1);
     REQUIRE(numNodes3 == 1);
     HIP_CHECK(hipEventDestroy(event1));
+    HIP_CHECK(hipGraphDestroy(graph1));
+    HIP_CHECK(hipGraphDestroy(graph2));
+    HIP_CHECK(hipGraphDestroy(graph3));
   }
   HIP_CHECK(hipStreamDestroy(stream3));
   HIP_CHECK(hipStreamDestroy(stream2));
@@ -797,10 +815,13 @@ TEST_CASE("Unit_hipStreamBeginCapture_DetectingInvalidCapture") {
   dummyKernel<<<1, 1, 0, stream1>>>();
   // Since stream2 is already in capture mode due to event wait
   // hipStreamBeginCapture on stream2 is expected to return error.
-  REQUIRE(hipSuccess != hipStreamBeginCapture(stream2,
-        hipStreamCaptureModeGlobal));
+  REQUIRE(hipSuccess != hipStreamBeginCapture(stream2, hipStreamCaptureModeGlobal));
+  hipGraph_t graph;
+  HIP_CHECK(hipStreamEndCapture(stream1, &graph));
+  HIP_CHECK(hipGraphDestroy(graph));
   HIP_CHECK(hipStreamDestroy(stream2));
   HIP_CHECK(hipStreamDestroy(stream1));
+  HIP_CHECK(hipEventDestroy(event));
 }
 /* Test scenario 12
  */

--- a/catch/unit/streamperthread/hipStreamPerThread_Event.cc
+++ b/catch/unit/streamperthread/hipStreamPerThread_Event.cc
@@ -23,6 +23,7 @@ TEST_CASE("Unit_hipStreamPerThread_EventRecord") {
   hipEvent_t event;
   HIP_CHECK(hipEventCreate(&event));
   HIP_CHECK(hipEventRecord(event, hipStreamPerThread));
+  HIP_CHECK(hipEventSynchronize(event));
   HIP_CHECK(hipEventDestroy(event));
 }
 


### PR DESCRIPTION
## Associated JIRA ticket number/Github issue number
SWDEV-548241

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## What were the changes?

Added missing destroy calls and removed duplicate calls.

## Why are these changes needed?

To resolve memory leaks.

## Updated CHANGELOG?

<!-- Needed for Release updates for a ROCm release. -->

- [ ] Yes
- [x] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [x] No, Does not apply to this PR.

## Additional Checks

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally.
- [x] Any dependent changes have been merged.
