### PR TITLE
SWDEV-549705 - Fixed memleak in Unit_hipExtLaunchMultiKernelMultiDevi…

### DIFF
--- a/catch/unit/module/hipExtLaunchMultiKernelMultiDevice.cc
+++ b/catch/unit/module/hipExtLaunchMultiKernelMultiDevice.cc
@@ -133,4 +133,14 @@ TEST_CASE("Unit_hipExtLaunchMultiKernelMultiDevice_Functional") {
       REQUIRE(fabs(C_h[i] - (A_h[i] * A_h[i])) < 0.00000000001);
     }
   }
+
+  for (int i = 0; i < nGpu; i++) {
+    HIP_CHECK(hipFree(A_d[i]));
+    HIP_CHECK(hipFree(C_d[i]));
+    HIP_CHECK(hipStreamDestroy(stream[i]));
+  }
+
+  free(launchParamsList);
+  free(A_h);
+  free(C_h);
 }


### PR DESCRIPTION
…ce_Functional

## Associated JIRA ticket number/Github issue number
<!-- For example: "Closes #1234" or "Fixes SWDEV-123456" -->
Fixes [SWDEV-549705](https://ontrack-internal.amd.com/browse/SWDEV-549705)
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## What were the changes?
Fix memory leak in the test
<!-- Please give a short summary of the change. -->

## Why are these changes needed?
The test was missing calls to hipFree/hipStreamDestroy
<!-- Please explain the motivation behind the change and why this solves the given problem. -->

## Updated CHANGELOG?

<!-- Needed for Release updates for a ROCm release. -->

- [ ] Yes
- [x] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [x] No, Does not apply to this PR.

## Additional Checks

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally.
- [x] Any dependent changes have been merged.
