### PR TITLE
SWDEV-543997 - Expose numXCC device property in hipGetDevicePropertie…

### DIFF
--- a/catch/unit/device/hipGetDeviceAttribute.cc
+++ b/catch/unit/device/hipGetDeviceAttribute.cc
@@ -230,6 +230,8 @@ TEST_CASE("Unit_hipGetDeviceAttribute_CheckAttrValues") {
   HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
                                       hipDeviceAttributeManagedMemory,
                                       props.managedMemory));
+  HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
+                                      hipDeviceAttributeNumberOfXccs));
 #endif
 
   HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
@@ -419,7 +421,7 @@ constexpr AttributeToStringMap<33> kCudaOnlyAttributes{
 #endif
 
 #if HT_AMD
-constexpr AttributeToStringMap<17> kAmdOnlyAttributes{{
+constexpr AttributeToStringMap<18> kAmdOnlyAttributes{{
     {hipDeviceAttributeClockInstructionRate, "hipDeviceAttributeClockInstructionRate"},
     {hipDeviceAttributeUnused3, "hipDeviceAttributeUnused3"},
     {hipDeviceAttributeMaxSharedMemoryPerMultiprocessor,
@@ -442,7 +444,8 @@ constexpr AttributeToStringMap<17> kAmdOnlyAttributes{{
     {hipDeviceAttributeImageSupport, "hipDeviceAttributeImageSupport"},
     {hipDeviceAttributePhysicalMultiProcessorCount,
      "hipDeviceAttributePhysicalMultiProcessorCount"},
-    {hipDeviceAttributeFineGrainSupport, "hipDeviceAttributeFineGrainSupport"}
+    {hipDeviceAttributeFineGrainSupport, "hipDeviceAttributeFineGrainSupport"},
+    {hipDeviceAttributeNumberOfXccs, "hipDeviceAttributeNumberOfXccs"}
     // {hipDeviceAttributeWallClockRate, "hipDeviceAttributeWallClockRate"}
 }};
 #endif

--- a/catch/unit/device/hipGetDeviceAttribute.cc
+++ b/catch/unit/device/hipGetDeviceAttribute.cc
@@ -35,9 +35,8 @@ THE SOFTWARE.
  * Query for a specific device attribute.
  */
 
-static hipError_t test_hipDeviceGetAttribute(int deviceId,
-                                      hipDeviceAttribute_t attr,
-                                      int expectedValue = -1) {
+static hipError_t test_hipDeviceGetAttribute(int deviceId, hipDeviceAttribute_t attr,
+                                             int expectedValue = -1) {
   int value = 0;
   std::cout << "Test hipDeviceGetAttribute attribute " << attr;
   if (expectedValue != -1) {
@@ -52,19 +51,16 @@ static hipError_t test_hipDeviceGetAttribute(int deviceId,
   return hipSuccess;
 }
 
-static hipError_t test_hipDeviceGetHdpAddress(int deviceId,
-                hipDeviceAttribute_t attr,
-                uint32_t* expectedValue) {
+static hipError_t test_hipDeviceGetHdpAddress(int deviceId, hipDeviceAttribute_t attr,
+                                              uint32_t* expectedValue) {
   uint32_t* value = 0;
   std::cout << "Test hipDeviceGetHdpAddress attribute " << attr;
   if (expectedValue != reinterpret_cast<uint32_t*>(0xdeadbeef)) {
     std::cout << " expected value " << expectedValue;
   }
-  HIP_CHECK(hipDeviceGetAttribute(reinterpret_cast<int*>(&value),
-                                       attr, deviceId));
+  HIP_CHECK(hipDeviceGetAttribute(reinterpret_cast<int*>(&value), attr, deviceId));
   std::cout << " actual value " << value << std::endl;
-  if ((expectedValue != reinterpret_cast<uint32_t*>(0xdeadbeef)) &&
-       value != expectedValue) {
+  if ((expectedValue != reinterpret_cast<uint32_t*>(0xdeadbeef)) && value != expectedValue) {
     std::cout << "fail" << std::endl;
     return hipErrorInvalidValue;
   }
@@ -90,167 +86,110 @@ TEST_CASE("Unit_hipGetDeviceAttribute_CheckAttrValues") {
   HIP_CHECK(hipGetDeviceProperties(&props, deviceId));
   printf("info: running on device #%d %s\n", deviceId, props.name);
 
-  HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                                  hipDeviceAttributeMaxThreadsPerBlock,
-                                  props.maxThreadsPerBlock));
-  HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                                  hipDeviceAttributeMaxBlockDimX,
-                                  props.maxThreadsDim[0]));
-  HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                                  hipDeviceAttributeMaxBlockDimY,
-                                  props.maxThreadsDim[1]));
-  HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                                  hipDeviceAttributeMaxBlockDimZ,
-                                  props.maxThreadsDim[2]));
-  HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                                  hipDeviceAttributeMaxGridDimX,
-                                  props.maxGridSize[0]));
-  HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                                  hipDeviceAttributeMaxGridDimY,
-                                  props.maxGridSize[1]));
-  HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                                  hipDeviceAttributeMaxGridDimZ,
-                                  props.maxGridSize[2]));
-  HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                              hipDeviceAttributeMaxSharedMemoryPerBlock,
-                              props.sharedMemPerBlock));
-  HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                                  hipDeviceAttributeTotalConstantMemory,
-                                  props.totalConstMem));
-  HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                                      hipDeviceAttributeWarpSize,
-                                      props.warpSize));
-  HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                                  hipDeviceAttributeMaxRegistersPerBlock,
-                                  props.regsPerBlock));
-  HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                                      hipDeviceAttributeClockRate,
-                                      props.clockRate));
-  HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                                      hipDeviceAttributeMemoryClockRate,
-                                      props.memoryClockRate));
-  HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                                      hipDeviceAttributeMemoryBusWidth,
-                                      props.memoryBusWidth));
-  HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                                  hipDeviceAttributeMultiprocessorCount,
-                                  props.multiProcessorCount));
-  HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                                      hipDeviceAttributeIsMultiGpuBoard,
-                                      props.isMultiGpuBoard));
-  HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                                      hipDeviceAttributeComputeMode,
-                                      props.computeMode));
-  HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                                      hipDeviceAttributeL2CacheSize,
-                                      props.l2CacheSize));
-  HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                          hipDeviceAttributeMaxThreadsPerMultiProcessor,
-                          props.maxThreadsPerMultiProcessor));
-  HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                                  hipDeviceAttributeComputeCapabilityMajor,
-                                  props.major));
-  HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                                  hipDeviceAttributeComputeCapabilityMinor,
-                                  props.minor));
-  HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                                      hipDeviceAttributeConcurrentKernels,
-                                      props.concurrentKernels));
-  HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                                      hipDeviceAttributePciBusId,
-                                      props.pciBusID));
-  HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                                      hipDeviceAttributePciDeviceId,
-                                      props.pciDeviceID));
-  HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                                      hipDeviceAttributeIntegrated,
-                                      props.integrated));
-  HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                                      hipDeviceAttributeMaxTexture1DWidth,
-                                      props.maxTexture1D));
-  HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                                     hipDeviceAttributeMaxTexture2DWidth,
-                                     props.maxTexture2D[0]));
-  HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                                      hipDeviceAttributeMaxTexture2DHeight,
-                                      props.maxTexture2D[1]));
-  HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                                      hipDeviceAttributeMaxTexture3DWidth,
-                                      props.maxTexture3D[0]));
-  HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                                      hipDeviceAttributeMaxTexture3DHeight,
-                                      props.maxTexture3D[1]));
-  HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                                      hipDeviceAttributeMaxTexture3DDepth,
-                                      props.maxTexture3D[2]));
-  HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                                      hipDeviceAttributeCooperativeLaunch,
-                                      props.cooperativeLaunch));
-  HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                          hipDeviceAttributeCooperativeMultiDeviceLaunch,
-                          props.cooperativeMultiDeviceLaunch));
+  HIP_CHECK(test_hipDeviceGetAttribute(deviceId, hipDeviceAttributeMaxThreadsPerBlock,
+                                       props.maxThreadsPerBlock));
+  HIP_CHECK(
+      test_hipDeviceGetAttribute(deviceId, hipDeviceAttributeMaxBlockDimX, props.maxThreadsDim[0]));
+  HIP_CHECK(
+      test_hipDeviceGetAttribute(deviceId, hipDeviceAttributeMaxBlockDimY, props.maxThreadsDim[1]));
+  HIP_CHECK(
+      test_hipDeviceGetAttribute(deviceId, hipDeviceAttributeMaxBlockDimZ, props.maxThreadsDim[2]));
+  HIP_CHECK(
+      test_hipDeviceGetAttribute(deviceId, hipDeviceAttributeMaxGridDimX, props.maxGridSize[0]));
+  HIP_CHECK(
+      test_hipDeviceGetAttribute(deviceId, hipDeviceAttributeMaxGridDimY, props.maxGridSize[1]));
+  HIP_CHECK(
+      test_hipDeviceGetAttribute(deviceId, hipDeviceAttributeMaxGridDimZ, props.maxGridSize[2]));
+  HIP_CHECK(test_hipDeviceGetAttribute(deviceId, hipDeviceAttributeMaxSharedMemoryPerBlock,
+                                       props.sharedMemPerBlock));
+  HIP_CHECK(test_hipDeviceGetAttribute(deviceId, hipDeviceAttributeTotalConstantMemory,
+                                       props.totalConstMem));
+  HIP_CHECK(test_hipDeviceGetAttribute(deviceId, hipDeviceAttributeWarpSize, props.warpSize));
+  HIP_CHECK(test_hipDeviceGetAttribute(deviceId, hipDeviceAttributeMaxRegistersPerBlock,
+                                       props.regsPerBlock));
+  HIP_CHECK(test_hipDeviceGetAttribute(deviceId, hipDeviceAttributeClockRate, props.clockRate));
+  HIP_CHECK(test_hipDeviceGetAttribute(deviceId, hipDeviceAttributeMemoryClockRate,
+                                       props.memoryClockRate));
+  HIP_CHECK(
+      test_hipDeviceGetAttribute(deviceId, hipDeviceAttributeMemoryBusWidth, props.memoryBusWidth));
+  HIP_CHECK(test_hipDeviceGetAttribute(deviceId, hipDeviceAttributeMultiprocessorCount,
+                                       props.multiProcessorCount));
+  HIP_CHECK(test_hipDeviceGetAttribute(deviceId, hipDeviceAttributeIsMultiGpuBoard,
+                                       props.isMultiGpuBoard));
+  HIP_CHECK(test_hipDeviceGetAttribute(deviceId, hipDeviceAttributeComputeMode, props.computeMode));
+  HIP_CHECK(test_hipDeviceGetAttribute(deviceId, hipDeviceAttributeL2CacheSize, props.l2CacheSize));
+  HIP_CHECK(test_hipDeviceGetAttribute(deviceId, hipDeviceAttributeMaxThreadsPerMultiProcessor,
+                                       props.maxThreadsPerMultiProcessor));
+  HIP_CHECK(
+      test_hipDeviceGetAttribute(deviceId, hipDeviceAttributeComputeCapabilityMajor, props.major));
+  HIP_CHECK(
+      test_hipDeviceGetAttribute(deviceId, hipDeviceAttributeComputeCapabilityMinor, props.minor));
+  HIP_CHECK(test_hipDeviceGetAttribute(deviceId, hipDeviceAttributeConcurrentKernels,
+                                       props.concurrentKernels));
+  HIP_CHECK(test_hipDeviceGetAttribute(deviceId, hipDeviceAttributePciBusId, props.pciBusID));
+  HIP_CHECK(test_hipDeviceGetAttribute(deviceId, hipDeviceAttributePciDeviceId, props.pciDeviceID));
+  HIP_CHECK(test_hipDeviceGetAttribute(deviceId, hipDeviceAttributeIntegrated, props.integrated));
+  HIP_CHECK(test_hipDeviceGetAttribute(deviceId, hipDeviceAttributeMaxTexture1DWidth,
+                                       props.maxTexture1D));
+  HIP_CHECK(test_hipDeviceGetAttribute(deviceId, hipDeviceAttributeMaxTexture2DWidth,
+                                       props.maxTexture2D[0]));
+  HIP_CHECK(test_hipDeviceGetAttribute(deviceId, hipDeviceAttributeMaxTexture2DHeight,
+                                       props.maxTexture2D[1]));
+  HIP_CHECK(test_hipDeviceGetAttribute(deviceId, hipDeviceAttributeMaxTexture3DWidth,
+                                       props.maxTexture3D[0]));
+  HIP_CHECK(test_hipDeviceGetAttribute(deviceId, hipDeviceAttributeMaxTexture3DHeight,
+                                       props.maxTexture3D[1]));
+  HIP_CHECK(test_hipDeviceGetAttribute(deviceId, hipDeviceAttributeMaxTexture3DDepth,
+                                       props.maxTexture3D[2]));
+  HIP_CHECK(test_hipDeviceGetAttribute(deviceId, hipDeviceAttributeCooperativeLaunch,
+                                       props.cooperativeLaunch));
+  HIP_CHECK(test_hipDeviceGetAttribute(deviceId, hipDeviceAttributeCooperativeMultiDeviceLaunch,
+                                       props.cooperativeMultiDeviceLaunch));
 
 #if HT_AMD
+  HIP_CHECK(test_hipDeviceGetAttribute(deviceId, hipDeviceAttributeMaxSharedMemoryPerMultiprocessor,
+                                       props.maxSharedMemoryPerMultiProcessor));
+  HIP_CHECK(test_hipDeviceGetHdpAddress(deviceId, hipDeviceAttributeHdpMemFlushCntl,
+                                        props.hdpMemFlushCntl));
+  HIP_CHECK(test_hipDeviceGetHdpAddress(deviceId, hipDeviceAttributeHdpRegFlushCntl,
+                                        props.hdpRegFlushCntl));
+  HIP_CHECK(test_hipDeviceGetAttribute(deviceId, hipDeviceAttributeDirectManagedMemAccessFromHost,
+                                       props.directManagedMemAccessFromHost));
+  HIP_CHECK(test_hipDeviceGetAttribute(deviceId, hipDeviceAttributeConcurrentManagedAccess,
+                                       props.concurrentManagedAccess));
+  HIP_CHECK(test_hipDeviceGetAttribute(deviceId, hipDeviceAttributePageableMemoryAccess,
+                                       props.pageableMemoryAccess));
   HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                      hipDeviceAttributeMaxSharedMemoryPerMultiprocessor,
-                      props.maxSharedMemoryPerMultiProcessor));
-  HIP_CHECK(test_hipDeviceGetHdpAddress(deviceId,
-                                     hipDeviceAttributeHdpMemFlushCntl,
-                                     props.hdpMemFlushCntl));
-  HIP_CHECK(test_hipDeviceGetHdpAddress(deviceId,
-                                     hipDeviceAttributeHdpRegFlushCntl,
-                                     props.hdpRegFlushCntl));
+                                       hipDeviceAttributePageableMemoryAccessUsesHostPageTables,
+                                       props.pageableMemoryAccessUsesHostPageTables));
   HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                            hipDeviceAttributeDirectManagedMemAccessFromHost,
-                            props.directManagedMemAccessFromHost));
+                                       hipDeviceAttributeCooperativeMultiDeviceUnmatchedFunc,
+                                       props.cooperativeMultiDeviceUnmatchedFunc));
   HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                            hipDeviceAttributeConcurrentManagedAccess,
-                            props.concurrentManagedAccess));
+                                       hipDeviceAttributeCooperativeMultiDeviceUnmatchedGridDim,
+                                       props.cooperativeMultiDeviceUnmatchedGridDim));
   HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                            hipDeviceAttributePageableMemoryAccess,
-                            props.pageableMemoryAccess));
+                                       hipDeviceAttributeCooperativeMultiDeviceUnmatchedBlockDim,
+                                       props.cooperativeMultiDeviceUnmatchedBlockDim));
   HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                    hipDeviceAttributePageableMemoryAccessUsesHostPageTables,
-                    props.pageableMemoryAccessUsesHostPageTables));
-  HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                    hipDeviceAttributeCooperativeMultiDeviceUnmatchedFunc,
-                    props.cooperativeMultiDeviceUnmatchedFunc));
-  HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                  hipDeviceAttributeCooperativeMultiDeviceUnmatchedGridDim,
-                  props.cooperativeMultiDeviceUnmatchedGridDim));
-  HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                  hipDeviceAttributeCooperativeMultiDeviceUnmatchedBlockDim,
-                  props.cooperativeMultiDeviceUnmatchedBlockDim));
-  HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                  hipDeviceAttributeCooperativeMultiDeviceUnmatchedSharedMem,
-                  props.cooperativeMultiDeviceUnmatchedSharedMem));
-  HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                                      hipDeviceAttributeAsicRevision,
-                                      props.asicRevision));
-  HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                                      hipDeviceAttributeManagedMemory,
-                                      props.managedMemory));
-  HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                                      hipDeviceAttributeNumberOfXccs));
+                                       hipDeviceAttributeCooperativeMultiDeviceUnmatchedSharedMem,
+                                       props.cooperativeMultiDeviceUnmatchedSharedMem));
+  HIP_CHECK(
+      test_hipDeviceGetAttribute(deviceId, hipDeviceAttributeAsicRevision, props.asicRevision));
+  HIP_CHECK(
+      test_hipDeviceGetAttribute(deviceId, hipDeviceAttributeManagedMemory, props.managedMemory));
+  HIP_CHECK(test_hipDeviceGetAttribute(deviceId, hipDeviceAttributeNumberOfXccs));
 #endif
 
-  HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                                     hipDeviceAttributeMaxPitch,
-                                     props.memPitch));
-  HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                                      hipDeviceAttributeTextureAlignment,
-                                      props.textureAlignment));
-  HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                                      hipDeviceAttributeKernelExecTimeout,
-                                      props.kernelExecTimeoutEnabled));
-  HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                                      hipDeviceAttributeCanMapHostMemory,
-                                      props.canMapHostMemory));
-  HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                                      hipDeviceAttributeEccEnabled,
-                                      props.ECCEnabled));
-  HIP_CHECK(test_hipDeviceGetAttribute(deviceId,
-                                       hipDeviceAttributeTexturePitchAlignment,
+  HIP_CHECK(test_hipDeviceGetAttribute(deviceId, hipDeviceAttributeMaxPitch, props.memPitch));
+  HIP_CHECK(test_hipDeviceGetAttribute(deviceId, hipDeviceAttributeTextureAlignment,
+                                       props.textureAlignment));
+  HIP_CHECK(test_hipDeviceGetAttribute(deviceId, hipDeviceAttributeKernelExecTimeout,
+                                       props.kernelExecTimeoutEnabled));
+  HIP_CHECK(test_hipDeviceGetAttribute(deviceId, hipDeviceAttributeCanMapHostMemory,
+                                       props.canMapHostMemory));
+  HIP_CHECK(test_hipDeviceGetAttribute(deviceId, hipDeviceAttributeEccEnabled, props.ECCEnabled));
+  HIP_CHECK(test_hipDeviceGetAttribute(deviceId, hipDeviceAttributeTexturePitchAlignment,
                                        props.texturePitchAlignment));
 }
 
@@ -285,27 +224,24 @@ TEST_CASE("Unit_hipDeviceGetAttribute_NegTst") {
 
   // pi is nullptr
   SECTION("pi is nullptr") {
-    REQUIRE_FALSE(hipSuccess == hipDeviceGetAttribute(nullptr,
-                                hipDeviceAttributePciBusId, device));
+    REQUIRE_FALSE(hipSuccess == hipDeviceGetAttribute(nullptr, hipDeviceAttributePciBusId, device));
   }
 
   // device is -1
   SECTION("device is -1") {
-    REQUIRE_FALSE(hipSuccess == hipDeviceGetAttribute(&pi,
-                                hipDeviceAttributePciBusId, -1));
+    REQUIRE_FALSE(hipSuccess == hipDeviceGetAttribute(&pi, hipDeviceAttributePciBusId, -1));
   }
 
   // device is Non Existing Device
   SECTION("device is Non Existing Device") {
-    REQUIRE_FALSE(hipSuccess == hipDeviceGetAttribute(&pi,
-                                hipDeviceAttributePciBusId, deviceCount));
+    REQUIRE_FALSE(hipSuccess ==
+                  hipDeviceGetAttribute(&pi, hipDeviceAttributePciBusId, deviceCount));
   }
 
   // attr is Invalid Attribute
   SECTION("attr is invalid") {
-    REQUIRE_FALSE(hipSuccess == hipDeviceGetAttribute(&pi,
-                                static_cast<hipDeviceAttribute_t>(-1),
-                                device));
+    REQUIRE_FALSE(hipSuccess ==
+                  hipDeviceGetAttribute(&pi, static_cast<hipDeviceAttribute_t>(-1), device));
   }
 }
 
@@ -314,72 +250,71 @@ using AttributeToStringMap = std::array<std::pair<hipDeviceAttribute_t, const ch
 
 namespace {
 
-constexpr AttributeToStringMap<58> kCommonAttributes{{
-    {hipDeviceAttributeEccEnabled, "hipDeviceAttributeEccEnabled"},
-    {hipDeviceAttributeCanMapHostMemory, "hipDeviceAttributeCanMapHostMemory"},
-    {hipDeviceAttributeClockRate, "hipDeviceAttributeClockRate"},
-    {hipDeviceAttributeComputeMode, "hipDeviceAttributeComputeMode"},
-    {hipDeviceAttributeConcurrentKernels, "hipDeviceAttributeConcurrentKernels"},
-    {hipDeviceAttributeConcurrentManagedAccess, "hipDeviceAttributeConcurrentManagedAccess"},
-    {hipDeviceAttributeCooperativeLaunch, "hipDeviceAttributeCooperativeLaunch"},
-    {hipDeviceAttributeCooperativeMultiDeviceLaunch,
-     "hipDeviceAttributeCooperativeMultiDeviceLaunch"},
-    {hipDeviceAttributeDirectManagedMemAccessFromHost,
-     "hipDeviceAttributeDirectManagedMemAccessFromHost"},
-    {hipDeviceAttributeIntegrated, "hipDeviceAttributeIntegrated"},
-    {hipDeviceAttributeIsMultiGpuBoard, "hipDeviceAttributeIsMultiGpuBoard"},
-    {hipDeviceAttributeKernelExecTimeout, "hipDeviceAttributeKernelExecTimeout"},
-    {hipDeviceAttributeL2CacheSize, "hipDeviceAttributeL2CacheSize"},
-    {hipDeviceAttributeLocalL1CacheSupported, "hipDeviceAttributeLocalL1CacheSupported"},
-    {hipDeviceAttributeComputeCapabilityMajor, "hipDeviceAttributeComputeCapabilityMajor"},
-    {hipDeviceAttributeManagedMemory, "hipDeviceAttributeManagedMemory"},
-    {hipDeviceAttributeMaxBlockDimX, "hipDeviceAttributeMaxBlockDimX"},
-    {hipDeviceAttributeMaxBlockDimY, "hipDeviceAttributeMaxBlockDimY"},
-    {hipDeviceAttributeMaxBlockDimZ, "hipDeviceAttributeMaxBlockDimZ"},
-    {hipDeviceAttributeMaxGridDimX, "hipDeviceAttributeMaxGridDimX"},
-    {hipDeviceAttributeMaxGridDimY, "hipDeviceAttributeMaxGridDimY"},
-    {hipDeviceAttributeMaxGridDimZ, "hipDeviceAttributeMaxGridDimZ"},
-    {hipDeviceAttributeMaxSurface1D, "hipDeviceAttributeMaxSurface1D"},
-    {hipDeviceAttributeMaxSurface2D, "hipDeviceAttributeMaxSurface2D"},
-    {hipDeviceAttributeMaxSurface3D, "hipDeviceAttributeMaxSurface3D"},
-    {hipDeviceAttributeMaxTexture1DWidth, "hipDeviceAttributeMaxTexture1DWidth"},
-    {hipDeviceAttributeMaxTexture1DLinear, "hipDeviceAttributeMaxTexture1DLinear"},
-    {hipDeviceAttributeMaxTexture2DWidth, "hipDeviceAttributeMaxTexture2DWidth"},
-    {hipDeviceAttributeMaxTexture2DHeight, "hipDeviceAttributeMaxTexture2DHeight"},
-    {hipDeviceAttributeMaxTexture3DWidth, "hipDeviceAttributeMaxTexture3DWidth"},
-    {hipDeviceAttributeMaxTexture3DHeight, "hipDeviceAttributeMaxTexture3DHeight"},
-    {hipDeviceAttributeMaxTexture3DDepth, "hipDeviceAttributeMaxTexture3DDepth"},
-    {hipDeviceAttributeMaxThreadsDim, "hipDeviceAttributeMaxThreadsDim"},
-    {hipDeviceAttributeMaxThreadsPerBlock, "hipDeviceAttributeMaxThreadsPerBlock"},
-    {hipDeviceAttributeMaxThreadsPerMultiProcessor,
-     "hipDeviceAttributeMaxThreadsPerMultiProcessor"},
-    {hipDeviceAttributeMaxPitch, "hipDeviceAttributeMaxPitch"},
-    {hipDeviceAttributeMemoryBusWidth, "hipDeviceAttributeMemoryBusWidth"},
-    {hipDeviceAttributeMemoryClockRate, "hipDeviceAttributeMemoryClockRate"},
-    {hipDeviceAttributeComputeCapabilityMinor, "hipDeviceAttributeComputeCapabilityMinor"},
-    {hipDeviceAttributeMultiprocessorCount, "hipDeviceAttributeMultiprocessorCount"},
-    {hipDeviceAttributeUnused1, "hipDeviceAttributeUnused1"},
-    {hipDeviceAttributePageableMemoryAccess, "hipDeviceAttributePageableMemoryAccess"},
-    {hipDeviceAttributePageableMemoryAccessUsesHostPageTables,
-     "hipDeviceAttributePageableMemoryAccessUsesHostPageTables"},
-    {hipDeviceAttributePciBusId, "hipDeviceAttributePciBusId"},
-    {hipDeviceAttributePciDeviceId, "hipDeviceAttributePciDeviceId"},
-    {hipDeviceAttributePciDomainID, "hipDeviceAttributePciDomainID"},
-    {hipDeviceAttributeMaxRegistersPerBlock, "hipDeviceAttributeMaxRegistersPerBlock"},
-    {hipDeviceAttributeMaxRegistersPerMultiprocessor,
-     "hipDeviceAttributeMaxRegistersPerMultiprocessor"},
-    {hipDeviceAttributeMaxSharedMemoryPerBlock, "hipDeviceAttributeMaxSharedMemoryPerBlock"},
-    {hipDeviceAttributeTextureAlignment, "hipDeviceAttributeTextureAlignment"},
-    {hipDeviceAttributeTexturePitchAlignment, "hipDeviceAttributeTexturePitchAlignment"},
-    {hipDeviceAttributeTotalConstantMemory, "hipDeviceAttributeTotalConstantMemory"},
-    {hipDeviceAttributeTotalGlobalMem, "hipDeviceAttributeTotalGlobalMem"},
-    {hipDeviceAttributeWarpSize, "hipDeviceAttributeWarpSize"},
-    {hipDeviceAttributeMemoryPoolsSupported, "hipDeviceAttributeMemoryPoolsSupported"},
-    {hipDeviceAttributeUnifiedAddressing, "hipDeviceAttributeUnifiedAddressing"},
-    {hipDeviceAttributeVirtualMemoryManagementSupported,
-     "hipDeviceAttributeVirtualMemoryManagementSupported"},
-    {hipDeviceAttributeHostRegisterSupported, "hipDeviceAttributeHostRegisterSupported"}
-}};
+constexpr AttributeToStringMap<58> kCommonAttributes{
+    {{hipDeviceAttributeEccEnabled, "hipDeviceAttributeEccEnabled"},
+     {hipDeviceAttributeCanMapHostMemory, "hipDeviceAttributeCanMapHostMemory"},
+     {hipDeviceAttributeClockRate, "hipDeviceAttributeClockRate"},
+     {hipDeviceAttributeComputeMode, "hipDeviceAttributeComputeMode"},
+     {hipDeviceAttributeConcurrentKernels, "hipDeviceAttributeConcurrentKernels"},
+     {hipDeviceAttributeConcurrentManagedAccess, "hipDeviceAttributeConcurrentManagedAccess"},
+     {hipDeviceAttributeCooperativeLaunch, "hipDeviceAttributeCooperativeLaunch"},
+     {hipDeviceAttributeCooperativeMultiDeviceLaunch,
+      "hipDeviceAttributeCooperativeMultiDeviceLaunch"},
+     {hipDeviceAttributeDirectManagedMemAccessFromHost,
+      "hipDeviceAttributeDirectManagedMemAccessFromHost"},
+     {hipDeviceAttributeIntegrated, "hipDeviceAttributeIntegrated"},
+     {hipDeviceAttributeIsMultiGpuBoard, "hipDeviceAttributeIsMultiGpuBoard"},
+     {hipDeviceAttributeKernelExecTimeout, "hipDeviceAttributeKernelExecTimeout"},
+     {hipDeviceAttributeL2CacheSize, "hipDeviceAttributeL2CacheSize"},
+     {hipDeviceAttributeLocalL1CacheSupported, "hipDeviceAttributeLocalL1CacheSupported"},
+     {hipDeviceAttributeComputeCapabilityMajor, "hipDeviceAttributeComputeCapabilityMajor"},
+     {hipDeviceAttributeManagedMemory, "hipDeviceAttributeManagedMemory"},
+     {hipDeviceAttributeMaxBlockDimX, "hipDeviceAttributeMaxBlockDimX"},
+     {hipDeviceAttributeMaxBlockDimY, "hipDeviceAttributeMaxBlockDimY"},
+     {hipDeviceAttributeMaxBlockDimZ, "hipDeviceAttributeMaxBlockDimZ"},
+     {hipDeviceAttributeMaxGridDimX, "hipDeviceAttributeMaxGridDimX"},
+     {hipDeviceAttributeMaxGridDimY, "hipDeviceAttributeMaxGridDimY"},
+     {hipDeviceAttributeMaxGridDimZ, "hipDeviceAttributeMaxGridDimZ"},
+     {hipDeviceAttributeMaxSurface1D, "hipDeviceAttributeMaxSurface1D"},
+     {hipDeviceAttributeMaxSurface2D, "hipDeviceAttributeMaxSurface2D"},
+     {hipDeviceAttributeMaxSurface3D, "hipDeviceAttributeMaxSurface3D"},
+     {hipDeviceAttributeMaxTexture1DWidth, "hipDeviceAttributeMaxTexture1DWidth"},
+     {hipDeviceAttributeMaxTexture1DLinear, "hipDeviceAttributeMaxTexture1DLinear"},
+     {hipDeviceAttributeMaxTexture2DWidth, "hipDeviceAttributeMaxTexture2DWidth"},
+     {hipDeviceAttributeMaxTexture2DHeight, "hipDeviceAttributeMaxTexture2DHeight"},
+     {hipDeviceAttributeMaxTexture3DWidth, "hipDeviceAttributeMaxTexture3DWidth"},
+     {hipDeviceAttributeMaxTexture3DHeight, "hipDeviceAttributeMaxTexture3DHeight"},
+     {hipDeviceAttributeMaxTexture3DDepth, "hipDeviceAttributeMaxTexture3DDepth"},
+     {hipDeviceAttributeMaxThreadsDim, "hipDeviceAttributeMaxThreadsDim"},
+     {hipDeviceAttributeMaxThreadsPerBlock, "hipDeviceAttributeMaxThreadsPerBlock"},
+     {hipDeviceAttributeMaxThreadsPerMultiProcessor,
+      "hipDeviceAttributeMaxThreadsPerMultiProcessor"},
+     {hipDeviceAttributeMaxPitch, "hipDeviceAttributeMaxPitch"},
+     {hipDeviceAttributeMemoryBusWidth, "hipDeviceAttributeMemoryBusWidth"},
+     {hipDeviceAttributeMemoryClockRate, "hipDeviceAttributeMemoryClockRate"},
+     {hipDeviceAttributeComputeCapabilityMinor, "hipDeviceAttributeComputeCapabilityMinor"},
+     {hipDeviceAttributeMultiprocessorCount, "hipDeviceAttributeMultiprocessorCount"},
+     {hipDeviceAttributeUnused1, "hipDeviceAttributeUnused1"},
+     {hipDeviceAttributePageableMemoryAccess, "hipDeviceAttributePageableMemoryAccess"},
+     {hipDeviceAttributePageableMemoryAccessUsesHostPageTables,
+      "hipDeviceAttributePageableMemoryAccessUsesHostPageTables"},
+     {hipDeviceAttributePciBusId, "hipDeviceAttributePciBusId"},
+     {hipDeviceAttributePciDeviceId, "hipDeviceAttributePciDeviceId"},
+     {hipDeviceAttributePciDomainID, "hipDeviceAttributePciDomainID"},
+     {hipDeviceAttributeMaxRegistersPerBlock, "hipDeviceAttributeMaxRegistersPerBlock"},
+     {hipDeviceAttributeMaxRegistersPerMultiprocessor,
+      "hipDeviceAttributeMaxRegistersPerMultiprocessor"},
+     {hipDeviceAttributeMaxSharedMemoryPerBlock, "hipDeviceAttributeMaxSharedMemoryPerBlock"},
+     {hipDeviceAttributeTextureAlignment, "hipDeviceAttributeTextureAlignment"},
+     {hipDeviceAttributeTexturePitchAlignment, "hipDeviceAttributeTexturePitchAlignment"},
+     {hipDeviceAttributeTotalConstantMemory, "hipDeviceAttributeTotalConstantMemory"},
+     {hipDeviceAttributeTotalGlobalMem, "hipDeviceAttributeTotalGlobalMem"},
+     {hipDeviceAttributeWarpSize, "hipDeviceAttributeWarpSize"},
+     {hipDeviceAttributeMemoryPoolsSupported, "hipDeviceAttributeMemoryPoolsSupported"},
+     {hipDeviceAttributeUnifiedAddressing, "hipDeviceAttributeUnifiedAddressing"},
+     {hipDeviceAttributeVirtualMemoryManagementSupported,
+      "hipDeviceAttributeVirtualMemoryManagementSupported"},
+     {hipDeviceAttributeHostRegisterSupported, "hipDeviceAttributeHostRegisterSupported"}}};
 
 #if HT_NVIDIA
 constexpr AttributeToStringMap<33> kCudaOnlyAttributes{
@@ -454,12 +389,13 @@ constexpr int kW = 60;
 
 }  // anonymous namespace
 
-template <size_t n> void printAttributes(const AttributeToStringMap<n>& attributes, const int device) {
+template <size_t n>
+void printAttributes(const AttributeToStringMap<n>& attributes, const int device) {
   hipError_t ret_val;
   for (const auto& attribute : attributes) {
     int64_t attribute_value = 0;
-    ret_val = hipDeviceGetAttribute(reinterpret_cast<int *>(&attribute_value),
-                                    attribute.first, device);
+    ret_val =
+        hipDeviceGetAttribute(reinterpret_cast<int*>(&attribute_value), attribute.first, device);
     std::cout << std::setw(kW) << std::string(attribute.second).append(": ");
     if (ret_val == hipSuccess)
       std::cout << attribute_value << "\n";
@@ -524,8 +460,7 @@ TEST_CASE("Print_Out_Attributes") {
 TEST_CASE("Unit_hipGetDeviceAttribute_hipDevAttrHostRegisterSupported") {
   hipError_t ret_val;
   int hipDevAttr = 0;
-  ret_val = hipDeviceGetAttribute(&hipDevAttr,
-                                  hipDeviceAttributeHostRegisterSupported, 0);
+  ret_val = hipDeviceGetAttribute(&hipDevAttr, hipDeviceAttributeHostRegisterSupported, 0);
   INFO("hipDeviceAttributeHostRegisterSupported: " << hipDevAttr);
 
   if (ret_val == hipSuccess) {
@@ -536,16 +471,16 @@ TEST_CASE("Unit_hipGetDeviceAttribute_hipDevAttrHostRegisterSupported") {
     HIP_CHECK(hipHostGetDevicePointer(&device_memory, x.get(), 0));
 
     HIP_CHECK(hipHostUnregister(x.get()));
-    HIP_CHECK_ERROR(hipHostGetDevicePointer(&device_memory, x.get(), 0),
-                    hipErrorInvalidValue);
+    HIP_CHECK_ERROR(hipHostGetDevicePointer(&device_memory, x.get(), 0), hipErrorInvalidValue);
   } else {
-    HipTest::HIP_SKIP_TEST("Skipping the test as GPU 0 doesn't support "
-             "hipDeviceAttributeHostRegisterSupported attribute.\n");
+    HipTest::HIP_SKIP_TEST(
+        "Skipping the test as GPU 0 doesn't support "
+        "hipDeviceAttributeHostRegisterSupported attribute.\n");
     return;
   }
 }
 
 /**
-* End doxygen group DeviceTest.
-* @}
-*/
+ * End doxygen group DeviceTest.
+ * @}
+ */


### PR DESCRIPTION
…s api

## Associated JIRA ticket number/Github issue number
SWDEV-543997
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## What were the changes?
Added new flag "hipDeviceAttributeNumberOfXccs" to get XCC values 

## Why are these changes needed?
 Currently there is no direct way to know how many XCCs are on a given a GPU, it will give  number of XCCs directly from hipGetDeviceProperites()

## Updated CHANGELOG?

- [X] Yes
- [ ] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [X] No, Does not apply to this PR.

## Additional Checks

- [X] I have added tests relevant to the introduced functionality, and the unit tests are passing locally.
- [X] Any dependent changes have been merged.
