### PR TITLE
SWDEV-547526 - Add missing free calls

### DIFF
--- a/catch/unit/module/hipExtLaunchMultiKernelMultiDevice.cc
+++ b/catch/unit/module/hipExtLaunchMultiKernelMultiDevice.cc
@@ -121,6 +121,7 @@ TEST_CASE("Unit_hipExtLaunchMultiKernelMultiDevice_Functional") {
 
   for (int j = 0; j < nGpu; j++) {
     HIP_CHECK(hipStreamSynchronize(stream[j]));
+    HIP_CHECK(hipStreamDestroy(stream[j]));
 
     hipDeviceProp_t props;
     HIP_CHECK(hipGetDeviceProperties(&props, j));
@@ -132,5 +133,12 @@ TEST_CASE("Unit_hipExtLaunchMultiKernelMultiDevice_Functional") {
     for (size_t i = 0; i < N; i++) {
       REQUIRE(fabs(C_h[i] - (A_h[i] * A_h[i])) < 0.00000000001);
     }
+
+    HIP_CHECK(hipFree(A_d[j]));
+    HIP_CHECK(hipFree(C_d[j]));
   }
+
+  free(A_h);
+  free(C_h);
+  free(launchParamsList);
 }

--- a/catch/unit/module/hipModule.cc
+++ b/catch/unit/module/hipModule.cc
@@ -91,7 +91,8 @@ bool testCodeObjFile(const char *codeObjFile) {
   HIP_CHECK(hipModuleLaunchKernel(Function, 1, 1, 1, LEN, 1, 1, 0,
                                  stream, NULL,
                                  reinterpret_cast<void**>(&config)));
-
+  
+  HIP_CHECK(hipStreamSynchronize(stream));
   HIP_CHECK(hipStreamDestroy(stream));
 
   HIP_CHECK(hipMemcpy(B, Bd, SIZE, hipMemcpyDeviceToHost));


### PR DESCRIPTION
## Associated JIRA ticket number/Github issue number
https://github.com/AMD-ROCm-Internal/hip-tests/pull/new/amd/dev/vstojilj/SWDEV-547526

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## What were the changes?

Added missing calls to release allocated memory.

## Why are these changes needed?

To resolve memory leaks.

## Updated CHANGELOG?

<!-- Needed for Release updates for a ROCm release. -->

- [ ] Yes
- [x] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [x] No, Does not apply to this PR.

## Additional Checks

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally.
- [x] Any dependent changes have been merged.
