### PR TITLE
SWDEV-544502 - Fixes in Unit_hipMallocManaged_MGpuMThread

### DIFF
--- a/catch/unit/memory/hipMallocMngdMultiThread.cc
+++ b/catch/unit/memory/hipMallocMngdMultiThread.cc
@@ -33,7 +33,8 @@ __global__ void HmmMultiThread(int n, float* x, float* y) {
 
 __global__ void KrnlWth2MemTypes(int* Hmm, int* Dptr, size_t n) {
   size_t index = blockIdx.x * blockDim.x + threadIdx.x;
-  for (size_t i = index; i < n; i++) {
+  size_t stride = blockDim.x * gridDim.x;
+  for (size_t i = index; i < n; i += stride) {
     Hmm[i] = Dptr[i] + 10;
   }
 }
@@ -81,6 +82,8 @@ static void LaunchKrnl(int* Hmm1, size_t NumElms, int InitVal, int GpuOrdnl, int
     WARN("Data Mismatch observed at line: " << __LINE__);
     IfTestPassed = false;
   }
+  HIPCHECK(hipFree(Hmm2));
+  HIPCHECK(hipStreamDestroy(strm));
 }
 
 static void LaunchKrnl2(int* Hmm, size_t NumElms, int InitVal, int HmmMem) {
@@ -383,6 +386,7 @@ TEST_CASE("Unit_hipMallocManaged_MGpuMThread") {
       }
     }
   }
+  HIP_CHECK(hipFree(Hmm1));
   REQUIRE(IfTestPassed);
 }
 


### PR DESCRIPTION
## Associated JIRA ticket number/Github issue number
<!-- For example: "Closes #1234" or "Fixes SWDEV-123456" -->
Fixes SWDEV-544502

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## What were the changes?
Changed the kernel used in the test plus added calls to hipFree

<!-- Please give a short summary of the change. -->

## Why are these changes needed?
The kernel used in the test is not right as multiple threads are overwriting the same output location at the same index.
This causes a lot of unnecessary overlapping work. In addition there is memory leaks for the managed memory.

<!-- Please explain the motivation behind the change and why this solves the given problem. -->

## Updated CHANGELOG?

<!-- Needed for Release updates for a ROCm release. -->

- [ ] Yes
- [x] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [x] No, Does not apply to this PR.

## Additional Checks

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally.
- [x] Any dependent changes have been merged.
