### PR TITLE
SWDEV-545485 - Fix memory leaks in memset performance tests

### DIFF
--- a/catch/performance/memset/hipMemset2DAsync.cc
+++ b/catch/performance/memset/hipMemset2DAsync.cc
@@ -40,6 +40,7 @@ class Memset2DAsyncBenchmark : public Benchmark<Memset2DAsyncBenchmark> {
       HIP_CHECK(hipMemset2DAsync(dst_.ptr(), dst_.pitch(), 17, dst_.width(), dst_.height(),
                                  stream_.stream()));
     }
+    HIP_CHECK(hipStreamSynchronize(stream_.stream()));
   }
 
  private:

--- a/catch/performance/memset/hipMemset3DAsync.cc
+++ b/catch/performance/memset/hipMemset3DAsync.cc
@@ -39,6 +39,7 @@ class Memset3DAsyncBenchmark : public Benchmark<Memset3DAsyncBenchmark> {
     TIMED_SECTION_STREAM(kTimerTypeEvent, stream_.stream()) {
       HIP_CHECK(hipMemset3DAsync(dst_.pitched_ptr(), 17, dst_.extent(), stream_.stream()));
     }
+    HIP_CHECK(hipStreamSynchronize(stream_.stream()));
   }
 
  private:

--- a/catch/performance/memset/hipMemsetAsync.cc
+++ b/catch/performance/memset/hipMemsetAsync.cc
@@ -39,6 +39,7 @@ class MemsetAsyncBenchmark : public Benchmark<MemsetAsyncBenchmark> {
     TIMED_SECTION_STREAM(kTimerTypeEvent, stream_.stream()) {
       HIP_CHECK(hipMemsetAsync(dst_.ptr(), 17, size_, stream_.stream()));
     }
+    HIP_CHECK(hipStreamSynchronize(stream_.stream()));
   }
 
  private:

--- a/catch/performance/memset/hipMemsetD16Async.cc
+++ b/catch/performance/memset/hipMemsetD16Async.cc
@@ -40,6 +40,7 @@ class MemsetD16AsyncBenchmark : public Benchmark<MemsetD16AsyncBenchmark> {
       HIP_CHECK(hipMemsetD16Async(reinterpret_cast<hipDeviceptr_t>(dst_.ptr()), 311, size_,
                                   stream_.stream()));
     }
+    HIP_CHECK(hipStreamSynchronize(stream_.stream()));
   }
 
  private:

--- a/catch/performance/memset/hipMemsetD32Async.cc
+++ b/catch/performance/memset/hipMemsetD32Async.cc
@@ -40,6 +40,7 @@ class MemsetD32AsyncBenchmark : public Benchmark<MemsetD32AsyncBenchmark> {
       HIP_CHECK(hipMemsetD32Async(reinterpret_cast<hipDeviceptr_t>(dst_.ptr()), 123'456, size_,
                                   stream_.stream()));
     }
+    HIP_CHECK(hipStreamSynchronize(stream_.stream()));
   }
 
  private:

--- a/catch/performance/memset/hipMemsetD8Async.cc
+++ b/catch/performance/memset/hipMemsetD8Async.cc
@@ -40,6 +40,7 @@ class MemsetD8AsyncBenchmark : public Benchmark<MemsetD8AsyncBenchmark> {
       HIP_CHECK(hipMemsetD8Async(reinterpret_cast<hipDeviceptr_t>(dst_.ptr()), 17, size_,
                                  stream_.stream()));
     }
+    HIP_CHECK(hipStreamSynchronize(stream_.stream()));
   }
 
  private:


### PR DESCRIPTION
Fixes SWDEV-545485

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## What were the changes?

Added hipStreamSynchronize after the memset async calls to make sure the copy operation completes.

## Why are these changes needed?

These tests are just measuring the memset apis but without stream synchronize, all the resources like stream, events etc. are still in use after the test completes and valgrind reports memory leaks due to it.

## Updated CHANGELOG?

<!-- Needed for Release updates for a ROCm release. -->

- [ ] Yes
- [x] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [x] No, Does not apply to this PR.

## Additional Checks

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally.
- [x] Any dependent changes have been merged.
