### PR TITLE
SWDEV-545482 - Refactor the error handling test cases

### DIFF
--- a/catch/unit/errorHandling/CMakeLists.txt
+++ b/catch/unit/errorHandling/CMakeLists.txt
@@ -29,3 +29,4 @@ hip_add_exe_to_target(NAME ErrorHandlingTest
                       COMPILE_OPTIONS -std=c++17)
 
 add_dependencies(build_tests hipGetLastErrorEnv_Exe hipPeekAtLastErrorEnv_Exe)
+set_property(GLOBAL APPEND PROPERTY G_INSTALL_EXE_TARGETS hipGetLastErrorEnv_Exe hipPeekAtLastErrorEnv_Exe)

--- a/catch/unit/errorHandling/hipGetLastError.cc
+++ b/catch/unit/errorHandling/hipGetLastError.cc
@@ -26,12 +26,6 @@ THE SOFTWARE.
 #include <chrono>  //NOLINT
 #include <thread>  //NOLINT
 
-#ifdef _WIN64
-#include <windows.h>
-#define setenv(x, y, z) _putenv_s(x, y)
-#define unsetenv(x) _putenv(x)
-#endif
-
 static constexpr size_t WIDTH = 1024;
 static constexpr size_t HEIGHT = 1024;
 static constexpr size_t N = 1024 * 1024;
@@ -961,43 +955,10 @@ TEST_CASE("Unit_hipGetLastError_with_Kernel_Invalid_Configuration") {
   HIP_CHECK(hipStreamDestroy(stream));
 }
 #endif
-/*
-New environment variable DEBUG_HIP_7_PREVIEW is added.
-This is used for enabling the backward incompatible changes before the next
-major ROCm release 7.0. This will be removed after the ROCm release 7.0.
-*/
 /**
  * Test Description
  * ------------------------
- *  - With Env Var DEBUG_HIP_7_PREVIEW, Verify hipGetLastError status
- *    with hipMalloc api invalid arg call.
- *    Status should be last Error reported in the thread/Runtime.
- * Test source
- * ------------------------
- *  - unit/errorHandling/hipGetLastError.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 6.4
- */
-TEST_CASE("Unit_hipGetLastError_With_EnvVar_Positive_Basic") {
-  if (setenv("DEBUG_HIP_7_PREVIEW", "1", 1) == 0) {
-    HIP_CHECK_ERROR(hipMalloc(nullptr, 1), hipErrorInvalidValue);
-    int *A_d;
-    HIP_CHECK(hipMalloc(&A_d, 1024));
-    HIP_CHECK_ERROR(hipGetLastError(), hipErrorInvalidValue);
-    HIP_CHECK_ERROR(hipGetLastError(), hipSuccess);
-    HIP_CHECK(hipFree(A_d));
-    HIP_CHECK_ERROR(hipGetLastError(), hipSuccess);
-    unsetenv("DEBUG_HIP_7_PREVIEW");
-  } else {
-    INFO("Env Not set");
-  }
-}
-/**
- * Test Description
- * ------------------------
- *  - With Env Var DEBUG_HIP_7_PREVIEW, Verify hipGetLastError status
- *    with an Error - Success calls
+ *  - Verify hipGetLastError status with an Error - Success calls
  *    Each time status should return the corresponding Error when it called.
  * Test source
  * ------------------------
@@ -1006,8 +967,7 @@ TEST_CASE("Unit_hipGetLastError_With_EnvVar_Positive_Basic") {
  * ------------------------
  *  - HIP_VERSION >= 6.4
  */
-TEST_CASE("Unit_hipGetLastError_With_EnvVar_Chk_Updated_Status") {
-  if (setenv("DEBUG_HIP_7_PREVIEW", "1", 1) == 0) {
+TEST_CASE("Unit_hipGetLastError_With_Chk_Updated_Status") {
     hipGraph_t graph;
     HIP_CHECK_ERROR(hipGraphCreate(&graph, 1), hipErrorInvalidValue);
     HIP_CHECK_ERROR(hipGetLastError(), hipErrorInvalidValue);
@@ -1015,16 +975,11 @@ TEST_CASE("Unit_hipGetLastError_With_EnvVar_Chk_Updated_Status") {
     HIP_CHECK(hipMalloc(&C_d, 1024));
     HIP_CHECK_ERROR(hipGetLastError(), hipSuccess);
     HIP_CHECK(hipFree(C_d));
-    unsetenv("DEBUG_HIP_7_PREVIEW");
-  } else {
-    INFO("Env Not set");
-  }
 }
 /**
  * Test Description
  * ------------------------
- *  - With Env Var DEBUG_HIP_7_PREVIEW, Verify hipGetLastError status
- *    along with hipPeekAtLastError.
+ *  - Verify hipGetLastError status along with hipPeekAtLastError.
  * Test source
  * ------------------------
  *  - unit/errorHandling/hipGetLastError.cc
@@ -1032,8 +987,7 @@ TEST_CASE("Unit_hipGetLastError_With_EnvVar_Chk_Updated_Status") {
  * ------------------------
  *  - HIP_VERSION >= 6.4
  */
-TEST_CASE("Unit_hipGetLastError_With_EnvVar_Chk_Along_hipPeekAtLastError") {
-  if (setenv("DEBUG_HIP_7_PREVIEW", "1", 1) == 0) {
+TEST_CASE("Unit_hipGetLastError_Chk_Along_hipPeekAtLastError") {
     hipGraph_t graph;
     HIP_CHECK_ERROR(hipGraphCreate(&graph, 1), hipErrorInvalidValue);
     HIP_CHECK_ERROR(hipPeekAtLastError(), hipErrorInvalidValue);
@@ -1042,15 +996,11 @@ TEST_CASE("Unit_hipGetLastError_With_EnvVar_Chk_Along_hipPeekAtLastError") {
     HIP_CHECK(hipFree(C_d));
     HIP_CHECK_ERROR(hipGetLastError(), hipErrorInvalidValue);
     HIP_CHECK_ERROR(hipGetLastError(), hipSuccess);
-    unsetenv("DEBUG_HIP_7_PREVIEW");
-  } else {
-    INFO("Env Not set");
-  }
 }
 /**
  * Test Description
  * ------------------------
- *  - With Env Var DEBUG_HIP_7_PREVIEW, Verify hipGetLastError status
+ *  - Verify hipGetLastError status
  *    with different Error and Success combinations.
  *    Each time status should return the corresponding Error when it called.
  * Test source
@@ -1060,11 +1010,10 @@ TEST_CASE("Unit_hipGetLastError_With_EnvVar_Chk_Along_hipPeekAtLastError") {
  * ------------------------
  *  - HIP_VERSION >= 6.4
  */
-TEST_CASE("Unit_hipGetLastError_With_EnvVar_Error_Combinations") {
+TEST_CASE("Unit_hipGetLastError_Error_Combinations") {
   int value = 0;
   hipGraph_t graph;
   SECTION("A case with Error-Error") {
-    if (setenv("DEBUG_HIP_7_PREVIEW", "1", 1) == 0) {
       HIP_CHECK(hipGetLastError());
       HIP_CHECK_ERROR(hipGraphCreate(&graph, 1), hipErrorInvalidValue);
       HIP_CHECK_ERROR(hipDeviceGetGraphMemAttribute(
@@ -1072,13 +1021,8 @@ TEST_CASE("Unit_hipGetLastError_With_EnvVar_Error_Combinations") {
                       hipErrorInvalidDevice);
       HIP_CHECK_ERROR(hipGetLastError(), hipErrorInvalidDevice);
       HIP_CHECK_ERROR(hipGetLastError(), hipSuccess);
-      unsetenv("DEBUG_HIP_7_PREVIEW");
-    } else {
-      INFO("Env Not set");
-    }
   }
   SECTION("A case with Error-Success-Error-Success") {
-    if (setenv("DEBUG_HIP_7_PREVIEW", "1", 1) == 0) {
       HIP_CHECK_ERROR(hipGraphCreate(&graph, 1), hipErrorInvalidValue);
       int *A_d;
       HIP_CHECK(hipMalloc(&A_d, 1024));
@@ -1088,13 +1032,8 @@ TEST_CASE("Unit_hipGetLastError_With_EnvVar_Error_Combinations") {
       HIP_CHECK(hipFree(A_d));
       HIP_CHECK_ERROR(hipGetLastError(), hipErrorInvalidDevice);
       HIP_CHECK_ERROR(hipGetLastError(), hipSuccess);
-      unsetenv("DEBUG_HIP_7_PREVIEW");
-    } else {
-      INFO("Env Not set");
-    }
   }
   SECTION("A case with Success-Error-Error-Success") {
-    if (setenv("DEBUG_HIP_7_PREVIEW", "1", 1) == 0) {
       int *A_d;
       HIP_CHECK(hipMalloc(&A_d, 1024));
       HIP_CHECK_ERROR(hipGraphCreate(&graph, 1), hipErrorInvalidValue);
@@ -1104,13 +1043,8 @@ TEST_CASE("Unit_hipGetLastError_With_EnvVar_Error_Combinations") {
       HIP_CHECK(hipFree(A_d));
       HIP_CHECK_ERROR(hipGetLastError(), hipErrorInvalidDevice);
       HIP_CHECK_ERROR(hipGetLastError(), hipSuccess);
-      unsetenv("DEBUG_HIP_7_PREVIEW");
-    } else {
-      INFO("Env Not set");
-    }
   }
   SECTION("A Case with Success-Error-Success-Error") {
-    if (setenv("DEBUG_HIP_7_PREVIEW", "1", 1) == 0) {
       int *A_d;
       HIP_CHECK(hipMalloc(&A_d, 1024));
       HIP_CHECK_ERROR(hipGraphCreate(&graph, 1), hipErrorInvalidValue);
@@ -1120,10 +1054,6 @@ TEST_CASE("Unit_hipGetLastError_With_EnvVar_Error_Combinations") {
                       hipErrorInvalidDevice);
       HIP_CHECK_ERROR(hipGetLastError(), hipErrorInvalidDevice);
       HIP_CHECK_ERROR(hipGetLastError(), hipSuccess);
-      unsetenv("DEBUG_HIP_7_PREVIEW");
-    } else {
-      INFO("Env Not set");
-    }
   }
 }
 
@@ -1136,8 +1066,7 @@ static void thread_func() {
 /**
  * Test Description
  * ------------------------
- *  - With Env Var DEBUG_HIP_7_PREVIEW, Verify hipGetLastError status with a
- *    runtime api invalid arg call.
+ *  - Verify hipGetLastError status with a runtime api invalid arg call.
  *    Check in other thread this error should not report by hipGetLastError()
  * Test source
  * ------------------------
@@ -1146,9 +1075,8 @@ static void thread_func() {
  * ------------------------
  *  - HIP_VERSION >= 6.4
  */
-TEST_CASE("Unit_hipGetLastError_With_EnvVar_With_Thread") {
+TEST_CASE("Unit_hipGetLastError_With_Thread") {
   hipGraph_t graph;
-  if (setenv("DEBUG_HIP_7_PREVIEW", "1", 1) == 0) {
     int *A_d;
     HIP_CHECK(hipMalloc(&A_d, 1024));
     HIP_CHECK_ERROR(hipGraphCreate(&graph, 1), hipErrorInvalidValue);
@@ -1157,16 +1085,11 @@ TEST_CASE("Unit_hipGetLastError_With_EnvVar_With_Thread") {
     HIP_CHECK(hipFree(A_d));
     HIP_CHECK_ERROR(hipGetLastError(), hipErrorInvalidValue);
     HIP_CHECK_ERROR(hipGetLastError(), hipSuccess);
-    unsetenv("DEBUG_HIP_7_PREVIEW");
-  } else {
-    INFO("Env Not set");
-  }
 }
 /**
  * Test Description
  * ------------------------
- *  - With Env Var DEBUG_HIP_7_PREVIEW, Verify hipGetLastError status
- *    in the multiple processes.
+ *  - Verify hipGetLastError status in the multiple processes.
  * Test source
  * ------------------------
  *  - unit/errorHandling/hipGetLastError.cc
@@ -1174,32 +1097,23 @@ TEST_CASE("Unit_hipGetLastError_With_EnvVar_With_Thread") {
  * ------------------------
  *  - HIP_VERSION >= 6.4
  */
-// Disabled due to test failure
-#if 0
-TEST_CASE("Unit_hipGetLastError_With_EnvVar_MultiProcess") {
+TEST_CASE("Unit_hipGetLastError_MultiProcess") {
   hipGraph_t graph;
-  if (setenv("DEBUG_HIP_7_PREVIEW", "1", 1) == 0) {
-    /*int *A_d;
+    int *A_d;
     HIP_CHECK(hipMalloc(&A_d, 1024));
-    HIP_CHECK_ERROR(hipGraphCreate(&graph, 1), hipErrorInvalidValue);*/
+    HIP_CHECK_ERROR(hipGraphCreate(&graph, 1), hipErrorInvalidValue);
     hip::SpawnProc proc("hipGetLastErrorEnv_Exe", true);
     HIP_CHECK_ERROR(hipGraphCreate(&graph, 1), hipErrorInvalidValue);
     REQUIRE(proc.run() == 1);
-    //HIP_CHECK(hipFree(A_d));
+    HIP_CHECK(hipFree(A_d));
     HIP_CHECK_ERROR(hipGetLastError(), hipErrorInvalidValue);
     HIP_CHECK_ERROR(hipGetLastError(), hipSuccess);
-    unsetenv("DEBUG_HIP_7_PREVIEW");
-  } else {
-    INFO("Env Not set");
-  }
 }
-#endif
 static void __global__ emptyKernl() { }
 /**
  * Test Description
  * ------------------------
- *  - With Env Var DEBUG_HIP_7_PREVIEW, Verify hipGetLastError status
- *    with Invalid Configuration in kernel call.
+ *  - Verify hipGetLastError status with Invalid Configuration in kernel call.
  *    Kernel call invalid configuration- blocks=0 & threadsPerBlock=0
  * Test source
  * ------------------------
@@ -1212,9 +1126,8 @@ static void __global__ emptyKernl() { }
 // Below test failed on NVIDIA due to error mismatch produced by the Invalid Kernel config.
 // For more details please check the ticket SWDEV-501851 comments.
 #if HT_AMD
-TEST_CASE("Unit_hipGetLastError_With_EnvVar_Kernel_Invalid_Config") {
+TEST_CASE("Unit_hipGetLastError_Kernel_Invalid_Config") {
   hipError_t ret;
-  if (setenv("DEBUG_HIP_7_PREVIEW", "1", 1) == 0) {
     hipLaunchKernelGGL(emptyKernl, dim3(0), dim3(0), 0, 0);
     int *A_d;
     HIP_CHECK(hipMalloc(&A_d, 1024));
@@ -1222,10 +1135,6 @@ TEST_CASE("Unit_hipGetLastError_With_EnvVar_Kernel_Invalid_Config") {
     REQUIRE(ret == hipErrorInvalidConfiguration);
     HIP_CHECK_ERROR(hipGetLastError(), hipSuccess);
     HIP_CHECK(hipFree(A_d));
-    unsetenv("DEBUG_HIP_7_PREVIEW");
-  } else {
-    INFO("Env Not set");
-  }
 }
 #endif
 /**

--- a/catch/unit/errorHandling/hipPeekAtLastError.cc
+++ b/catch/unit/errorHandling/hipPeekAtLastError.cc
@@ -21,12 +21,6 @@ THE SOFTWARE.
 #include <hip_test_process.hh>
 #include <threaded_zig_zag_test.hh>
 
-#ifdef _WIN64
-#include <windows.h>
-#define setenv(x, y, z) _putenv_s(x, y)
-#define unsetenv(x) _putenv(x)
-#endif
-
 /**
  * @addtogroup hipPeekAtLastError hipPeekAtLastError
  * @{
@@ -90,17 +84,10 @@ TEST_CASE("Unit_hipPeekAtLastError_Positive_Threaded") {
   HipPeekAtLastErrorTest test;
   test.run();
 }
-/*
- * New environment variable DEBUG_HIP_7_PREVIEW is added.
- * This is used for enabling the backward incompatible changes before the next
- * major ROCm release 7.0.
- * This will be removed after the ROCm release 7.0.
- */
 /**
  * Test Description
  * ------------------------
- *  - With Env Var DEBUG_HIP_7_PREVIEW, Verify hipPeekAtLastError status
- *    with hipMalloc api invalid arg call.
+ *  - Verify hipPeekAtLastError status with hipMalloc api invalid arg call.
  *    Status should be last Error reported in the thread/Runtime.
  * Test source
  * ------------------------
@@ -109,8 +96,7 @@ TEST_CASE("Unit_hipPeekAtLastError_Positive_Threaded") {
  * ------------------------
  *  - HIP_VERSION >= 6.4
  */
-TEST_CASE("Unit_hipPeekAtLastError_With_EnvVar_Positive_Basic") {
-  if (setenv("DEBUG_HIP_7_PREVIEW", "1", 1) == 0) {
+TEST_CASE("Unit_hipPeekAtLastError_Positive") {
     HIP_CHECK_ERROR(hipMalloc(nullptr, 1), hipErrorInvalidValue);
     int *A_d;
     HIP_CHECK(hipMalloc(&A_d, 1024));
@@ -118,16 +104,11 @@ TEST_CASE("Unit_hipPeekAtLastError_With_EnvVar_Positive_Basic") {
     HIP_CHECK(hipFree(A_d));
     HIP_CHECK_ERROR(hipPeekAtLastError(), hipErrorInvalidValue);
     HIP_CHECK_ERROR(hipPeekAtLastError(), hipErrorInvalidValue);
-    unsetenv("DEBUG_HIP_7_PREVIEW");
-  } else {
-    INFO("Env Not set");
-  }
 }
 /**
  * Test Description
  * ------------------------
- *  - With Env Var DEBUG_HIP_7_PREVIEW, Verify hipPeekAtLastError status
- *    with an Error - Success calls
+ *  - Verify hipPeekAtLastError status with an Error - Success calls
  *    Each time status should return the corresponding Error when it called.
  * Test source
  * ------------------------
@@ -136,8 +117,7 @@ TEST_CASE("Unit_hipPeekAtLastError_With_EnvVar_Positive_Basic") {
  * ------------------------
  *  - HIP_VERSION >= 6.4
  */
-TEST_CASE("Unit_hipPeekAtLastError_With_EnvVar_Chk_Updated_Status") {
-  if (setenv("DEBUG_HIP_7_PREVIEW", "1", 1) == 0) {
+TEST_CASE("Unit_hipPeekAtLastError_Chk_Updated_Status") {
     hipGraph_t graph;
     int value = 0;
     HIP_CHECK_ERROR(hipGraphCreate(&graph, 1), hipErrorInvalidValue);
@@ -149,16 +129,11 @@ TEST_CASE("Unit_hipPeekAtLastError_With_EnvVar_Chk_Updated_Status") {
                     hipErrorInvalidDevice);
     HIP_CHECK(hipFree(C_d));
     HIP_CHECK_ERROR(hipPeekAtLastError(), hipErrorInvalidDevice);
-    unsetenv("DEBUG_HIP_7_PREVIEW");
-  } else {
-    INFO("Env Not set");
-  }
 }
 /**
  * Test Description
  * ------------------------
- *  - With Env Var DEBUG_HIP_7_PREVIEW, Verify hipPeekAtLastError status
- *    along with the hipGetLastError API call.
+ *  - Verify hipPeekAtLastError status along with the hipGetLastError API call.
  * Test source
  * ------------------------
  *  - unit/errorHandling/hipPeekAtLastError.cc
@@ -166,8 +141,7 @@ TEST_CASE("Unit_hipPeekAtLastError_With_EnvVar_Chk_Updated_Status") {
  * ------------------------
  *  - HIP_VERSION >= 6.4
  */
-TEST_CASE("Unit_hipPeekAtLastError_With_EnvVar_Chk_Along_hipGetLastError") {
-  if (setenv("DEBUG_HIP_7_PREVIEW", "1", 1) == 0) {
+TEST_CASE("Unit_hipPeekAtLastError_Chk_Along_hipGetLastError") {
     hipGraph_t graph;
     HIP_CHECK_ERROR(hipGraphCreate(&graph, 1), hipErrorInvalidValue);
     HIP_CHECK_ERROR(hipGetLastError(), hipErrorInvalidValue);
@@ -177,16 +151,12 @@ TEST_CASE("Unit_hipPeekAtLastError_With_EnvVar_Chk_Along_hipGetLastError") {
     HIP_CHECK(hipMalloc(&C_d, 1024));
     HIP_CHECK(hipFree(C_d));
     HIP_CHECK_ERROR(hipPeekAtLastError(), hipSuccess);
-    unsetenv("DEBUG_HIP_7_PREVIEW");
-  } else {
-    INFO("Env Not set");
-  }
 }
 
 /**
  * Test Description
  * ------------------------
- *  - With Env Var DEBUG_HIP_7_PREVIEW, Verify hipPeekAtLastError status
+ *  - Verify hipPeekAtLastError status
  *    with different Error and Success combinations.
  *    Each time status should return the corresponding Error when it called.
  * Test source
@@ -196,11 +166,10 @@ TEST_CASE("Unit_hipPeekAtLastError_With_EnvVar_Chk_Along_hipGetLastError") {
  * ------------------------
  *  - HIP_VERSION >= 6.4
  */
-TEST_CASE("Unit_hipPeekAtLastError_With_EnvVar_Error_Combinations") {
+TEST_CASE("Unit_hipPeekAtLastError_Error_Combinations") {
   int value = 0;
   hipGraph_t graph;
   SECTION("A case with Error-Error-Success-Success") {
-    if (setenv("DEBUG_HIP_7_PREVIEW", "1", 1) == 0) {
       HIP_CHECK(hipPeekAtLastError());
       HIP_CHECK_ERROR(hipGraphCreate(&graph, 1), hipErrorInvalidValue);
       HIP_CHECK_ERROR(hipDeviceGetGraphMemAttribute(
@@ -211,13 +180,8 @@ TEST_CASE("Unit_hipPeekAtLastError_With_EnvVar_Error_Combinations") {
       HIP_CHECK(hipMalloc(&A_d, 1024));
       HIP_CHECK(hipFree(A_d));
       HIP_CHECK_ERROR(hipPeekAtLastError(), hipErrorInvalidDevice);
-      unsetenv("DEBUG_HIP_7_PREVIEW");
-    } else {
-      INFO("Env Not set");
-    }
   }
   SECTION("A case with Error-Success-Error-Success") {
-    if (setenv("DEBUG_HIP_7_PREVIEW", "1", 1) == 0) {
       HIP_CHECK_ERROR(hipGraphCreate(&graph, 1), hipErrorInvalidValue);
       int *A_d;
       HIP_CHECK(hipMalloc(&A_d, 1024));
@@ -226,13 +190,8 @@ TEST_CASE("Unit_hipPeekAtLastError_With_EnvVar_Error_Combinations") {
                       hipErrorInvalidDevice);
       HIP_CHECK(hipFree(A_d));
       HIP_CHECK_ERROR(hipPeekAtLastError(), hipErrorInvalidDevice);
-      unsetenv("DEBUG_HIP_7_PREVIEW");
-    } else {
-      INFO("Env Not set");
-    }
   }
   SECTION("A case with Success-Error-Error-Success") {
-    if (setenv("DEBUG_HIP_7_PREVIEW", "1", 1) == 0) {
       int *A_d;
       HIP_CHECK(hipMalloc(&A_d, 1024));
       HIP_CHECK_ERROR(hipGraphCreate(&graph, 1), hipErrorInvalidValue);
@@ -241,13 +200,8 @@ TEST_CASE("Unit_hipPeekAtLastError_With_EnvVar_Error_Combinations") {
                       hipErrorInvalidDevice);
       HIP_CHECK(hipFree(A_d));
       HIP_CHECK_ERROR(hipPeekAtLastError(), hipErrorInvalidDevice);
-      unsetenv("DEBUG_HIP_7_PREVIEW");
-    } else {
-      INFO("Env Not set");
-    }
   }
   SECTION("A Case with Success-Error-Success-Error") {
-    if (setenv("DEBUG_HIP_7_PREVIEW", "1", 1) == 0) {
       int *A_d;
       HIP_CHECK(hipMalloc(&A_d, 1024));
       HIP_CHECK_ERROR(hipGraphCreate(&graph, 1), hipErrorInvalidValue);
@@ -256,10 +210,6 @@ TEST_CASE("Unit_hipPeekAtLastError_With_EnvVar_Error_Combinations") {
                           -1, hipGraphMemAttrUsedMemCurrent, &value),
                       hipErrorInvalidDevice);
       HIP_CHECK_ERROR(hipPeekAtLastError(), hipErrorInvalidDevice);
-      unsetenv("DEBUG_HIP_7_PREVIEW");
-    } else {
-      INFO("Env Not set");
-    }
   }
 }
 
@@ -274,8 +224,7 @@ static void thread_func() {
 /**
  * Test Description
  * ------------------------
- *  - With Env Var DEBUG_HIP_7_PREVIEW, Verify hipPeekAtLastError status with a
- *    runtime api invalid arg call.
+ *  - Verify hipPeekAtLastError status with a runtime api invalid arg call.
  *    Check in other thread this error should not report by hipPeekAtLastError()
  * Test source
  * ------------------------
@@ -284,9 +233,8 @@ static void thread_func() {
  * ------------------------
  *  - HIP_VERSION >= 6.4
  */
-TEST_CASE("Unit_hipPeekAtLastError_With_EnvVar_With_Thread") {
+TEST_CASE("Unit_hipPeekAtLastError_With_Thread") {
   hipGraph_t graph;
-  if (setenv("DEBUG_HIP_7_PREVIEW", "1", 1) == 0) {
     int *A_d;
     HIP_CHECK(hipMalloc(&A_d, 1024));
     HIP_CHECK_ERROR(hipGraphCreate(&graph, 1), hipErrorInvalidValue);
@@ -294,16 +242,11 @@ TEST_CASE("Unit_hipPeekAtLastError_With_EnvVar_With_Thread") {
     t.join();
     HIP_CHECK(hipFree(A_d));
     HIP_CHECK_ERROR(hipPeekAtLastError(), hipErrorInvalidValue);
-    unsetenv("DEBUG_HIP_7_PREVIEW");
-  } else {
-    INFO("Env Not set");
-  }
 }
 /**
  * Test Description
  * ------------------------
- *  - With Env Var DEBUG_HIP_7_PREVIEW, Verify hipPeekAtLastError status
- *    in the multiple processes.
+ *  - Verify hipPeekAtLastError status in the multiple processes.
  * Test source
  * ------------------------
  *  - unit/errorHandling/hipPeekAtLastError.cc
@@ -311,32 +254,23 @@ TEST_CASE("Unit_hipPeekAtLastError_With_EnvVar_With_Thread") {
  * ------------------------
  *  - HIP_VERSION >= 6.4
  */
-// Disabled due to test failure
-#if 0
-TEST_CASE("Unit_hipPeekAtLastError_With_EnvVar_MultiProcess") {
+TEST_CASE("Unit_hipPeekAtLastError_MultiProcess") {
   hipGraph_t graph;
-  if (setenv("DEBUG_HIP_7_PREVIEW", "1", 1) == 0) {
-    /*int *A_d;
+    int *A_d;
     HIP_CHECK(hipMalloc(&A_d, 1024));
-    HIP_CHECK_ERROR(hipGraphCreate(&graph, 1), hipErrorInvalidValue);*/
+    HIP_CHECK_ERROR(hipGraphCreate(&graph, 1), hipErrorInvalidValue);
     hip::SpawnProc proc("hipPeekAtLastErrorEnv_Exe", true);
     HIP_CHECK_ERROR(hipGraphCreate(&graph, 1), hipErrorInvalidValue);
     HIP_CHECK_ERROR(hipPeekAtLastError(), hipErrorInvalidValue);
     REQUIRE(proc.run() == 1);
-    //HIP_CHECK(hipFree(A_d));
+    HIP_CHECK(hipFree(A_d));
     HIP_CHECK_ERROR(hipPeekAtLastError(), hipErrorInvalidValue);
-    unsetenv("DEBUG_HIP_7_PREVIEW");
-  } else {
-    INFO("Env Not set");
-  }
 }
-#endif
 static void __global__ emptyKernl() {}
 /**
  * Test Description
  * ------------------------
- *  - With Env Var DEBUG_HIP_7_PREVIEW, Verify hipPeekAtLastError status
- *    with Invalid Configuration in kernel call.
+ *  - Verify hipPeekAtLastError status with Invalid Configuration in kernel call.
  *    Kernel call invalid configuration- blocks=0 & threadsPerBlock=0
  * Test source
  * ------------------------
@@ -348,17 +282,14 @@ static void __global__ emptyKernl() {}
 // Below test failed on NVIDIA due to error mismatch produced by the Invalid Kernel config.
 // For more details please check the ticket SWDEV-501896 comments.
 #if HT_AMD
-TEST_CASE("Unit_hipPeekAtLastError_With_EnvVar_Kernel_Invalid_Config") {
+TEST_CASE("Unit_hipPeekAtLastError_Kernel_Invalid_Config") {
   hipError_t ret;
-  if (setenv("DEBUG_HIP_7_PREVIEW", "1", 1) == 0) {
     hipLaunchKernelGGL(emptyKernl, dim3(0), dim3(0), 0, 0);
     int *A_d;
     HIP_CHECK(hipMalloc(&A_d, 1024));
     ret = hipPeekAtLastError();
     REQUIRE(ret == hipErrorInvalidConfiguration);
     HIP_CHECK(hipFree(A_d));
-    unsetenv("DEBUG_HIP_7_PREVIEW");
-  }
 }
 #endif
 /**


### PR DESCRIPTION
Fixes SWDEV-545482

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## What were the changes?

Refactored the error handling test cases by removing the usage of env var DEBUG_HIP_7_PREVIEW and also removing duplicate test cases

## Why are these changes needed?
DEBUG_HIP_7_PREVIEW env var was introduced earlier for breaking changes coming in ROCm 7.0 and now that has been removed.

<!-- Please explain the motivation behind the change and why this solves the given problem. -->
DEBUG_HIP_7_PREVIEW env var has been removed from HIP runtime and using that in the hip tests can result in failure of some test cases, and hence the env var has to be removed and the test case had to be corrected as per the new behavior.


## Updated CHANGELOG?

<!-- Needed for Release updates for a ROCm release. -->

- [ ] Yes
- [ ] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [x] No, Does not apply to this PR.

## Additional Checks

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally.
- [x] Any dependent changes have been merged.
