### PR TITLE
SWDEV-534207 - Solve more phoenix mem test failures

### DIFF
--- a/catch/unit/memory/hipFreeMipmappedArray.cc
+++ b/catch/unit/memory/hipFreeMipmappedArray.cc
@@ -56,6 +56,8 @@ TEMPLATE_TEST_CASE("Unit_hipFreeMipmappedArrayImplicitSyncArray", "", char, floa
   HIP_CHECK(hipGetDeviceProperties(&props, 0))
 
   for (auto numLevels : levels) {
+    INFO(" extent: (" << extent.width << ", " << extent.height << ", " << extent.depth << ") and "
+                      << numLevels << " levels. Total VRAM: " << props.totalGlobalMem);
     if (extent.width * extent.height * extent.depth * numLevels * sizeof(TestType) >
         props.totalGlobalMem) {
       // some devices will not have enough memory allocate the 6GB required for the biggest extent

--- a/catch/unit/memory/hipFreeMipmappedArray.cc
+++ b/catch/unit/memory/hipFreeMipmappedArray.cc
@@ -59,14 +59,17 @@ TEMPLATE_TEST_CASE("Unit_hipFreeMipmappedArrayImplicitSyncArray", "", char, floa
     INFO(" extent: (" << extent.width << ", " << extent.height << ", " << extent.depth << ") and "
                       << numLevels << " levels. Total VRAM: " << props.totalGlobalMem);
     if (extent.width * extent.height * extent.depth * numLevels * sizeof(TestType) >
-        props.totalGlobalMem) {
+        props.totalGlobalMem / 2) {
       // some devices will not have enough memory allocate the 6GB required for the biggest extent
-      // We skip the test in that case (and no warning is needed)
+      // We would skip the test if the extent would require more than half of the global memory.
+      // Note that totalGlobalMem is not an exact measurement of the available memory for
+      // compute and we cannot use it as an exact value, so we use half
+      // (we use SUCCEED as no warning is needed)
       SUCCEED(
-          "Device does not have enough global memory to allocate a mipmapped array using this "
-          " extent: ("
-          << extent.width << ", " << extent.height << ", " << extent.depth << ") and " << numLevels
-          << " levels");
+          "Device might not have enough global memory to allocate a mipmapped array using this "
+          "extent; "
+          "test will not be run. Total global memory: "
+          << props.totalGlobalMem);
       continue;
     }
 


### PR DESCRIPTION
## Associated JIRA ticket number/Github issue number
SWDEV-534207

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## What were the changes?

Avoid test failures on the GPU 740M. Also print more information on Unit_hipFreeMipmappedArrayImplicitSyncArray when the test fails using Catch INFO() macros.

## Why are these changes needed?

That specific GPU does not have enough memory for some of the extents used in 'Unit_hipFreeMipmappedArrayImplicitSyncArray - float'. Those extends should be skipped

## Updated CHANGELOG?

- [ ] Yes
- [X] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [X] No, Does not apply to this PR.

## Additional Checks

- [X] I have added tests relevant to the introduced functionality, and the unit tests are passing locally.
- [ ] Any dependent changes have been merged.
