### PR TITLE
SWDEV-544900 - Change hip-test test case name

### DIFF
--- a/catch/unit/callback/hipKernelNameRefByPtr.cc
+++ b/catch/unit/callback/hipKernelNameRefByPtr.cc
@@ -67,7 +67,7 @@ TEST_CASE("Unit_hipKernelNameRefByPtr_Positive_Basic") {
  *  - HIP_VERSION >= 5.2
  *  - Platform specific (AMD)
  */
-TEST_CASE("Unit_hipKernelNameRefByPtr_Negative_StreamNullptr") {
+TEST_CASE("Unit_hipKernelNameRefByPtr_Positive_StreamNullptr") {
   const void* kernel_ptr{reinterpret_cast<const void*>(&test_kernel)};
   StreamGuard stream_guard{Streams::nullstream};
 


### PR DESCRIPTION
## Associated JIRA ticket number/Github issue number
SWDEV-544900
<!-- For example: "Closes #1234" or "Fixes SWDEV-123456" -->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## What were the changes?
Changed test name: Unit_hipKernelNameRefByPtr_Negative_StreamNullpr to Unit_hipKernelNameRefByPtr_Positive_StreamNullptr.
<!-- Please give a short summary of the change. -->

## Why are these changes needed?
The test name now reflects the logic of the test.
<!-- Please explain the motivation behind the change and why this solves the given problem. -->

## Updated CHANGELOG?

<!-- Needed for Release updates for a ROCm release. -->

- [ ] Yes
- [x] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [x] No, Does not apply to this PR.

## Additional Checks

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally.
- [x] Any dependent changes have been merged.
