### PR TITLE
SWDEV-532647 - [catch2][dtest] Enable hipGetLastError on Kernel Failure tests for AMD

### DIFF
--- a/catch/hipTestMain/config/config_amd_linux
+++ b/catch/hipTestMain/config/config_amd_linux
@@ -740,10 +740,6 @@
 	    "=== SWDEV-538600 : This test fails in Linux PSDB ===",
 	    "Unit_hipMemPoolMaxAlloc",
 	    "Unit_hipStreamPerThread_ChildProc",
-        "=== SWDEV-536226 : Below three tests were disabled due to hang issue ===",
-        "Unit_hipGetLastError_KernelFailure_ValidAndInvalidOperations",
-        "Unit_hipGetLastError_KernelFailure_TwoDevices",
-        "Unit_hipGetLastError_KernelFailure_TwoStreams",
     #endif
     #if defined gfx90a || defined gfx942 || defined gfx950
         "=== SWDEV-443630 : Below test failed in stress test on 19/01/24 ===",


### PR DESCRIPTION

## Associated JIRA ticket number/Github issue number
SWDEV-532647

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## What were the changes?
Enable tests for AMD for hipGetLastError on Kernel Failure Which are merged in https://github.com/AMD-ROCm-Internal/hip-tests/pull/247

## Why are these changes needed?
The tests will be skipped, to enable hipGetLastError on Kernel Failure tests for AMD added these changes

## Updated CHANGELOG?
- [ ] Yes
- [x] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [x] No, Does not apply to this PR.

## Additional Checks

- [x] I have added tests relevant to the introduced functionality, and the unit tests are passing locally.
- [x] Any dependent changes have been merged.
