### PR TITLE
SWDEV-541066-[catch2][dtest]-Create stream capture test for multiple stream with cross dependencies.

### DIFF
--- a/catch/unit/stream/hipStreamWaitEvent.cc
+++ b/catch/unit/stream/hipStreamWaitEvent.cc
@@ -33,7 +33,6 @@ different stream with hipStreamWaitEvent api
 #include <mutex>
 
 using namespace std;
-constexpr int N = 1 << 20;
 
 TEST_CASE("Unit_hipStreamWaitEvent_Negative") {
   enum class StreamTestType { NullStream = 0, StreamPerThread, CreatedStream };

--- a/catch/unit/stream/hipStreamWaitEvent.cc
+++ b/catch/unit/stream/hipStreamWaitEvent.cc
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
@@ -18,13 +18,23 @@ THE SOFTWARE.
 */
 /*
 Testcase Scenarios :
-Unit_hipStreamWaitEvent_Negative - Test unsuccessful hipStreamWaitEvent when either event or flags are invalid
-Unit_hipStreamWaitEvent_Default - Test simple waiting for an event with hipStreamWaitEvent api
-Unit_hipStreamWaitEvent_DifferentStreams - Test waiting for an event on a different stream with hipStreamWaitEvent api
+Unit_hipStreamWaitEvent_Negative - Test unsuccessful hipStreamWaitEvent when either event or flags
+are invalid Unit_hipStreamWaitEvent_Default - Test simple waiting for an event with
+hipStreamWaitEvent api Unit_hipStreamWaitEvent_DifferentStreams - Test waiting for an event on a
+different stream with hipStreamWaitEvent api
 */
 
 #include <hip_test_common.hh>
+#include "../memory/mempool_common.hh"
 #include <utils.hh>
+#include <thread>
+#include <vector>
+#include <condition_variable>
+#include <mutex>
+
+using namespace std;
+constexpr int N = 1 << 20;
+
 TEST_CASE("Unit_hipStreamWaitEvent_Negative") {
   enum class StreamTestType { NullStream = 0, StreamPerThread, CreatedStream };
 
@@ -130,3 +140,121 @@ TEST_CASE("Unit_hipStreamWaitEvent_DifferentStreams") {
   HIP_CHECK(hipStreamDestroy(unblockingStream));
   HIP_CHECK(hipEventDestroy(waitEvent));
 }
+#if HT_NVIDIA
+TEST_CASE("Unit_hipStreamWaitEvent_StreamCapture_WithCross_Dependency") {
+  GENERATE_CAPTURE();
+  streamMemAllocTest testObj(N);
+  // create multiple streams
+  hipStream_t stream1, stream2, stream3;
+  HIP_CHECK(hipStreamCreate(&stream1));
+  HIP_CHECK(hipStreamCreate(&stream2));
+  HIP_CHECK(hipStreamCreate(&stream3));
+  // Create host buffer with test data
+  testObj.createHostBufferWithData();
+  hipEvent_t Event1, Event2, Event3, Event4;
+  HIP_CHECK(hipEventCreate(&Event1));
+  HIP_CHECK(hipEventCreate(&Event2));
+  HIP_CHECK(hipEventCreate(&Event3));
+  HIP_CHECK(hipEventCreate(&Event4));
+  BEGIN_CAPTURE(stream1);
+  testObj.allocFromDefMempool(stream1);
+  testObj.transferToMempool(stream1);
+  HIP_CHECK(hipEventRecord(Event1, stream1));
+  HIP_CHECK(hipStreamWaitEvent(stream2, Event1, 0));
+  testObj.runKernel(stream2);
+  HIP_CHECK(hipEventRecord(Event2, stream2));
+  HIP_CHECK(hipStreamWaitEvent(stream3, Event2, 0));
+  testObj.transferFromMempool(stream3);
+  testObj.freeDevBuf(stream3);
+  HIP_CHECK(hipEventRecord(Event3, stream3));
+  HIP_CHECK(hipStreamWaitEvent(stream2, Event3, 0));
+  HIP_CHECK(hipEventRecord(Event4, stream2));
+  HIP_CHECK(hipStreamWaitEvent(stream1, Event4, 0));
+  END_CAPTURE(stream1);
+  HIP_CHECK(hipStreamSynchronize(stream1));
+  // Validate the Result;
+  REQUIRE(true == testObj.validateResult());
+  testObj.freeHostBuf();
+  HIP_CHECK(hipEventDestroy(Event4));
+  HIP_CHECK(hipEventDestroy(Event3));
+  HIP_CHECK(hipEventDestroy(Event2));
+  HIP_CHECK(hipEventDestroy(Event1));
+  HIP_CHECK(hipStreamDestroy(stream3));
+  HIP_CHECK(hipStreamDestroy(stream2));
+  HIP_CHECK(hipStreamDestroy(stream1));
+}
+condition_variable cvar;
+mutex mut;
+int var = 0;
+void threadFunc_3(hipStream_t stream3, streamMemAllocTest testObj) {
+  hipEvent_t Event3, Event4;
+  hipStream_t stream4;
+  HIP_CHECK(hipEventCreate(&Event3));
+  HIP_CHECK(hipEventCreate(&Event4));
+  HIP_CHECK(hipStreamCreate(&stream4));
+  HIP_CHECK(hipEventRecord(Event3, stream3));
+  HIP_CHECK(hipStreamWaitEvent(stream4, Event3, 0));
+  testObj.transferFromMempool(stream4);
+  testObj.freeDevBuf(stream4);
+  HIP_CHECK(hipEventRecord(Event4, stream4));
+  HIP_CHECK(hipStreamWaitEvent(stream3, Event4, 0));
+}
+
+void threadFunc_2(hipStream_t stream1, streamMemAllocTest testObj) {
+  hipEvent_t Event2, Event5;
+  hipStream_t stream3;
+  HIP_CHECK(hipEventCreate(&Event2));
+  HIP_CHECK(hipEventCreate(&Event5));
+  HIP_CHECK(hipStreamCreate(&stream3));
+  HIP_CHECK(hipEventRecord(Event2, stream1));
+  HIP_CHECK(hipStreamWaitEvent(stream3, Event2, 0));
+  unique_lock<mutex> ulock(mut);
+  cvar.wait(ulock, [] { return (var == 1) ? true : false; });
+  testObj.runKernel(stream3);
+  std::thread t3(threadFunc_3, stream3, testObj);
+  t3.join();
+  HIP_CHECK(hipEventRecord(Event5, stream3));
+  HIP_CHECK(hipStreamWaitEvent(stream1, Event5, 0));
+}
+
+void threadFunc_1(hipStream_t stream1, streamMemAllocTest testObj) {
+  lock_guard<mutex> lock(mut);
+  hipEvent_t Event1, Event6;
+  hipStream_t stream2;
+  HIP_CHECK(hipEventCreate(&Event1));
+  HIP_CHECK(hipEventCreate(&Event6));
+  HIP_CHECK(hipStreamCreate(&stream2));
+  HIP_CHECK(hipEventRecord(Event1, stream1));
+  HIP_CHECK(hipStreamWaitEvent(stream2, Event1, 0));
+  testObj.transferToMempool(stream2);
+  var = 1;
+  cvar.notify_one();
+  HIP_CHECK(hipEventRecord(Event6, stream2));
+  HIP_CHECK(hipStreamWaitEvent(stream1, Event6, 0));
+}
+
+TEST_CASE("Unit_hipStreamWaitEvent_StreamCapture_CrossDepend_MultiThread") {
+  hipStream_t stream1;
+  HIP_CHECK(hipStreamCreate(&stream1));
+  streamMemAllocTest testObj(512);
+  testObj.createHostBufferWithData();
+  hipStreamCaptureMode flags = GENERATE(hipStreamCaptureModeGlobal, hipStreamCaptureModeRelaxed);
+  HIP_CHECK(hipStreamBeginCapture(stream1, flags));
+  testObj.allocFromDefMempool(stream1);
+  std::thread t1(threadFunc_1, stream1, testObj);
+  std::thread t2(threadFunc_2, stream1, testObj);
+  t1.join();
+  t2.join();
+  hipGraph_t graph = nullptr;
+  hipGraphExec_t graph_exec = nullptr;
+  HIP_CHECK(hipStreamEndCapture(stream1, &graph));
+  HIP_CHECK(hipGraphInstantiate(&graph_exec, graph, nullptr, nullptr, 0));
+  HIP_CHECK(hipGraphLaunch(graph_exec, stream1));
+  HIP_CHECK(hipStreamSynchronize(stream1));
+  // Validate the Result;
+  REQUIRE(true == testObj.validateResult());
+  HIP_CHECK(hipGraphExecDestroy(graph_exec));
+  HIP_CHECK(hipGraphDestroy(graph));
+  testObj.freeHostBuf();
+}
+#endif


### PR DESCRIPTION
## Associated JIRA ticket number/Github issue number
<!-- For example: "Closes #1234" or "Fixes SWDEV-123456" -->
SWDEV-541066
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [X] Continuous Integration

## What were the changes?
Stream capture tests for the following scenarios.
1. capture same graph from multiple streams with cross dependencies
2. capture same graph from multiple streams from multiple threads with cross dependencies
<!-- Please give a short summary of the change. -->

## Why are these changes needed?
To increase the coverage of tests with stream capture apis.
<!-- Please explain the motivation behind the change and why this solves the given problem. -->

## Updated CHANGELOG?

<!-- Needed for Release updates for a ROCm release. -->

- [ ] Yes
- [X] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [X] No, Does not apply to this PR.

## Additional Checks

- [X] I have added tests relevant to the introduced functionality, and the unit tests are passing locally.
- [ ] Any dependent changes have been merged.
