### PR TITLE
SWDEV-534394 - Add test for kernel launch stream on different device

### DIFF
--- a/catch/unit/module/hip_module_launch_kernel_common.hh
+++ b/catch/unit/module/hip_module_launch_kernel_common.hh
@@ -229,6 +229,24 @@ template <ExtModuleLaunchKernelSig* func> void ModuleLaunchKernelNegativeParamet
                     hipErrorInvalidValue);
   }
 
+  SECTION("Stream not on the same device") {
+    int numDevices = 0;
+    HIP_CHECK(hipGetDeviceCount(&numDevices));
+    if (numDevices < 2) {
+      SUCCEED("skipped the testcase as number of devices is less than 2");
+    } else {
+      hipFunction_t f = GetKernel(mg.module(), "Kernel42");
+      void* extra[0] = {};
+      hipStream_t s1;
+      HIP_CHECK(hipSetDevice(1));
+      HIP_CHECK(hipStreamCreate(&s1));
+      HIP_CHECK(hipSetDevice(0));
+      HIP_CHECK_ERROR(func(f, 1, 1, 1, 1, 1, 1, 0, s1, nullptr, extra, nullptr, nullptr, 0u),
+                      hipErrorInvalidResourceHandle);
+      HIP_CHECK(hipStreamDestroy(s1));
+    }
+  }
+
   SECTION("Invalid extra") {
     hipFunction_t f = GetKernel(mg.module(), "Kernel42");
     void* extra[0] = {};


### PR DESCRIPTION
## Associated JIRA ticket number/Github issue number
<!-- For example: "Closes #1234" or "Fixes SWDEV-123456" -->
https://ontrack-internal.amd.com/browse/SWDEV-534394

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## What were the changes?

<!-- Please give a short summary of the change. -->
Add test for launching kernel on a stream that's on a different device, expected to return hipErrorInvalidResourceHandle

## Why are these changes needed?

<!-- Please explain the motivation behind the change and why this solves the given problem. -->
To match NVIDIA's behavior

## Updated CHANGELOG?

<!-- Needed for Release updates for a ROCm release. -->

- [ ] Yes
- [x] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [x] No, Does not apply to this PR.

## Additional Checks

- [x] I have added tests relevant to the introduced functionality, and the unit tests are passing locally.
- [ ] Any dependent changes have been merged.
