### PR TITLE
SWDEV-491277 - add stream capture test for ExtSemaphoreSignal APIs

### DIFF
--- a/catch/unit/vulkan_interop/hipSignalExternalSemaphoresAsync.cc
+++ b/catch/unit/vulkan_interop/hipSignalExternalSemaphoresAsync.cc
@@ -73,3 +73,27 @@ TEST_CASE("Unit_hipSignalExternalSemaphoresAsync_Vulkan_Negative_Parameters") {
     HIP_CHECK(hipDestroyExternalSemaphore(hip_ext_semaphore));
   }
 }
+
+/**
+ * Test Description
+ * ------------------------
+ *    - Test hipSignalExternalSemaphoresAsync while stream is capturing.
+ * Test source
+ * ------------------------
+ *    - unit/vulkan_interop/hipSignalExternalSemaphoresAsync.cc
+ * Test requirements
+ * ------------------------
+ *    - HIP_VERSION >= 6.0
+ */
+TEST_CASE("Unit_hipSignalExternalSemaphoresAsync_Vulkan_Capture") {
+  VulkanTest vkt(enable_validation);
+  hipExternalSemaphoreSignalParams signal_params = {};
+  signal_params.params.fence.value = 1;
+  const auto hip_ext_semaphore = ImportBinarySemaphore(vkt);
+
+  hipError_t memcpy_err = hipSuccess;
+  BEGIN_CAPTURE_SYNC(memcpy_err, true);
+  HIP_CHECK_ERROR(hipSignalExternalSemaphoresAsync(&hip_ext_semaphore, &signal_params, 1,
+    nullptr), memcpy_err);
+  END_CAPTURE_SYNC(memcpy_err);
+}

--- a/catch/unit/vulkan_interop/hipWaitExternalSemaphoresAsync.cc
+++ b/catch/unit/vulkan_interop/hipWaitExternalSemaphoresAsync.cc
@@ -72,3 +72,27 @@ TEST_CASE("Unit_hipWaitExternalSemaphoresAsync_Vulkan_Negative_Parameters") {
     HIP_CHECK(hipDestroyExternalSemaphore(hip_ext_semaphore));
   }
 }
+
+/**
+ * Test Description
+ * ------------------------
+ *    - Test hipWaitExternalSemaphoresAsync while stream is capturing.
+ * Test source
+ * ------------------------
+ *    - unit/vulkan_interop/hipWaitExternalSemaphoresAsync.cc
+ * Test requirements
+ * ------------------------
+ *    - HIP_VERSION >= 6.0
+ */
+TEST_CASE("Unit_hipWaitExternalSemaphoresAsync_Vulkan_Capture") {
+  VulkanTest vkt(enable_validation);
+  hipExternalSemaphoreWaitParams wait_params = {};
+  wait_params.params.fence.value = 1;
+  const auto hip_ext_semaphore = ImportBinarySemaphore(vkt);
+
+  hipError_t memcpy_err = hipSuccess;
+  BEGIN_CAPTURE_SYNC(memcpy_err, true);
+  HIP_CHECK_ERROR(hipWaitExternalSemaphoresAsync(&hip_ext_semaphore, &wait_params, 1,
+    nullptr), memcpy_err);
+  END_CAPTURE_SYNC(memcpy_err);
+}


### PR DESCRIPTION
## Associated JIRA ticket number/Github issue number
SWDEV-491277
<!-- For example: "Closes #1234" or "Fixes SWDEV-123456" -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## What were the changes?
add stream capture test for ExtSemaphoreSignal APIs
<!-- Please give a short summary of the change. -->

## Why are these changes needed?
To test ExtSemaphoreSignal and ExtSemaphoreWait APIs when capturing stream
<!-- Please explain the motivation behind the change and why this solves the given problem. -->

## Updated CHANGELOG?

<!-- Needed for Release updates for a ROCm release. -->

- [ ] Yes
- [x] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [x] No, Does not apply to this PR.

## Additional Checks

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally.
- [ ] Any dependent changes have been merged.
