### PR TITLE
SWDEV-533232 Adapt the tests to use the cooperative_groups num_thread…

### DIFF
--- a/catch/include/warp_common.hh
+++ b/catch/include/warp_common.hh
@@ -44,7 +44,7 @@ inline __device__ bool deactivate_thread(const uint64_t* const active_masks) {
   const auto warp =
       cooperative_groups::tiled_partition(cooperative_groups::this_thread_block(), warpSize);
   const auto block = cooperative_groups::this_thread_block();
-  const auto warps_per_block = (block.size() + warpSize - 1) / warpSize;
+  const auto warps_per_block = (block.num_threads() + warpSize - 1) / warpSize;
   const auto block_rank = (blockIdx.z * gridDim.y + blockIdx.y) * gridDim.x + blockIdx.x;
   const auto idx = block_rank * warps_per_block + block.thread_rank() / warpSize;
   return !(active_masks[idx] & (static_cast<uint64_t>(1) << warp.thread_rank()));

--- a/catch/unit/atomics/arithmetic_common.hh
+++ b/catch/unit/atomics/arithmetic_common.hh
@@ -225,7 +225,7 @@ __global__ void TestKernel(TestType* const global_mem, TestType* const old_vals,
     __syncthreads();
   }
 
-  const auto n = cooperative_groups::this_grid().size();
+  const auto n = cooperative_groups::this_grid().num_threads();
 
   TestType* atomic_addr = PitchedOffset(mem, pitch, tid % width);
 

--- a/catch/unit/atomics/atomicExch_common.hh
+++ b/catch/unit/atomics/atomicExch_common.hh
@@ -97,7 +97,7 @@ __global__ void atomic_exch_kernel(T* const global_mem, T* const old_vals, const
     __syncthreads();
   }
 
-  const auto n = cooperative_groups::this_grid().size();
+  const auto n = cooperative_groups::this_grid().num_threads();
 
   T* atomic_addr = pitched_offset(mem, pitch, tid % width);
 

--- a/catch/unit/atomics/bitwise_common.hh
+++ b/catch/unit/atomics/bitwise_common.hh
@@ -135,7 +135,7 @@ __global__ void TestKernel(TestType* const global_mem, TestType* const old_vals,
     __syncthreads();
   }
 
-  const auto n = cooperative_groups::this_grid().size();
+  const auto n = cooperative_groups::this_grid().num_threads();
 
   TestType* atomic_addr = PitchedOffset(mem, pitch, tid % width);
 

--- a/catch/unit/atomics/min_max_common.hh
+++ b/catch/unit/atomics/min_max_common.hh
@@ -160,7 +160,7 @@ __global__ void TestKernel(TestType* const global_mem, TestType* const old_vals,
     __syncthreads();
   }
 
-  const auto n = cooperative_groups::this_grid().size();
+  const auto n = cooperative_groups::this_grid().num_threads();
 
   TestType* atomic_addr = PitchedOffset(mem, pitch, tid % width);
 

--- a/catch/unit/cooperativeGrps/coalesced_group.cc
+++ b/catch/unit/cooperativeGrps/coalesced_group.cc
@@ -43,7 +43,7 @@ static __global__ void coalesced_group_size_getter(unsigned int* sizes, uint64_t
       cg::tiled_partition<ksize>(cg::this_thread_block());
   if (active_mask & (static_cast<uint64_t>(1) << tile.thread_rank())) {
     BaseType active = cg::coalesced_threads();
-    sizes[thread_rank_in_grid()] = active.size();
+    sizes[thread_rank_in_grid()] = active.num_threads();
   }
 }
 
@@ -699,12 +699,12 @@ __global__ void coalesced_group_sync_check(T* global_data, unsigned int* wait_mo
   const auto block = cg::this_thread_block();
   const cg::thread_block_tile<ksize> partition = cg::tiled_partition<ksize>(block);
 
-  const auto data_idx = [&block](unsigned int i) { return use_global ? i : (i % block.size()); };
+  const auto data_idx = [&block](unsigned int i) { return use_global ? i : (i % block.num_threads()); };
 
-  const auto partition_rank = block.thread_rank() / partition.size();
+  const auto partition_rank = block.thread_rank() / partition.num_threads();
 
-  const auto block_base_idx = tid / block.size() * block.size();
-  const auto tile_base_idx = block_base_idx + partition_rank * partition.size();
+  const auto block_base_idx = tid / block.num_threads() * block.num_threads();
+  const auto tile_base_idx = block_base_idx + partition_rank * partition.num_threads();
   const auto wait_modifier = wait_modifiers[tid];
 
   if (active_mask & (static_cast<uint64_t>(1) << partition.thread_rank())) {
@@ -713,8 +713,8 @@ __global__ void coalesced_group_sync_check(T* global_data, unsigned int* wait_mo
     data[data_idx(tid)] = active.thread_rank();
     active.sync();
     bool valid = true;
-    for (auto i = 0; i < active.size(); ++i) {
-      const auto expected = (active.thread_rank() + i) % active.size();
+    for (auto i = 0; i < active.num_threads(); ++i) {
+      const auto expected = (active.thread_rank() + i) % active.num_threads();
       unsigned int active_count = 0;
       int offset = -1;
       while (active_count <= expected) {

--- a/catch/unit/cooperativeGrps/coalesced_group_tiled_partition.cc
+++ b/catch/unit/cooperativeGrps/coalesced_group_tiled_partition.cc
@@ -83,7 +83,7 @@ static auto coalesce_threads(const uint64_t mask, unsigned int warp_size) {
 __device__ bool deactivate_thread(uint64_t* active_masks, unsigned int warp_size) {
   const auto warp = cg::tiled_partition(cg::this_thread_block(), warp_size);
   const auto block = cg::this_thread_block();
-  const auto warps_per_block = (block.size() + warp_size - 1) / warp_size;
+  const auto warps_per_block = (block.num_threads() + warp_size - 1) / warp_size;
   const auto block_rank = (blockIdx.z * gridDim.y + blockIdx.y) * gridDim.x + blockIdx.x;
   const auto idx = block_rank * warps_per_block + block.thread_rank() / warp_size;
   return !(active_masks[idx] & (1u << warp.thread_rank()));
@@ -96,7 +96,7 @@ __global__ void coalesced_group_tiled_partition_size_getter(uint64_t* active_mas
   if (deactivate_thread(active_masks, warp_size)) {
     return;
   }
-  sizes[thread_rank_in_grid()] = cg::tiled_partition(cg::coalesced_threads(), tile_size).size();
+  sizes[thread_rank_in_grid()] = cg::tiled_partition(cg::coalesced_threads(), tile_size).num_threads();
 }
 
 __global__ void coalesced_group_tiled_partition_thread_rank_getter(uint64_t* active_masks,
@@ -548,13 +548,13 @@ __global__ void coalesced_group_tiled_partition_sync_check(uint64_t* active_mask
   const auto block = cg::this_thread_block();
   const auto coalesced = cg::coalesced_threads();
   const auto partition = cg::tiled_partition(coalesced, tile_size);
-  const auto data_idx = [&block](unsigned int i) { return use_global ? i : (i % block.size()); };
+  const auto data_idx = [&block](unsigned int i) { return use_global ? i : (i % block.num_threads()); };
 
   const auto wait_modifier = wait_modifiers[tid];
 
-  const auto block_rank = tid / block.size();
+  const auto block_rank = tid / block.num_threads();
   const auto warp_rank = block.thread_rank() / warp_size;
-  const auto warp_base = block_rank * block.size() + warp_rank * warp_size;
+  const auto warp_base = block_rank * block.num_threads() + warp_rank * warp_size;
   const auto global_idx = warp_base + coalesced.thread_rank();
 
   busy_wait(wait_modifier);
@@ -566,7 +566,7 @@ __global__ void coalesced_group_tiled_partition_sync_check(uint64_t* active_mask
   for (auto i = 0u; i < tile_size; ++i) {
     const auto target_rank_in_tile = (coalesced.thread_rank() + i) % tile_size;
     const auto target_rank_in_warp = tile_rank * tile_size + target_rank_in_tile;
-    if (target_rank_in_warp >= coalesced.size()) {
+    if (target_rank_in_warp >= coalesced.num_threads()) {
       continue;
     }
     if (!(valid &= (data[data_idx(warp_base + target_rank_in_warp)] == target_rank_in_tile))) {

--- a/catch/unit/cooperativeGrps/coalesced_groups_shfl_down_old.cc
+++ b/catch/unit/cooperativeGrps/coalesced_groups_shfl_down_old.cc
@@ -38,7 +38,7 @@ using namespace cooperative_groups;
 #define WAVE_SIZE 32
 
 __device__ int reduction_kernel_shfl_down(coalesced_group const& g, int val) {
-  int sz = g.size();
+  int sz = g.num_threads();
 
   for (int i = sz / 2; i > 0; i >>= 1) {
     val += g.shfl_down(val, i);
@@ -76,7 +76,7 @@ __global__ void kernel_cg_group_partition_shfl_down(int* result, unsigned int ti
     // Choose a leader thread to print the results
     if (threadBlockCGTy.thread_rank() == 0) {
       printf(" Creating %d groups, of tile size %d threads:\n\n",
-             (int)threadBlockCGTy.size() / tileSz, tileSz);
+             (int)threadBlockCGTy.num_threads() / tileSz, tileSz);
     }
 
     threadBlockCGTy.sync();
@@ -94,7 +94,7 @@ __global__ void kernel_cg_group_partition_shfl_down(int* result, unsigned int ti
       printf(
           "   Sum of all ranks 0..%d in this tiledPartition group using shfl_down is %d (expected "
           "%d)\n",
-          tiledPartition.size() - 1, outputSum, expectedSum);
+          tiledPartition.num_threads() - 1, outputSum, expectedSum);
       result[threadBlockCGTy.thread_rank() / (tileSz)] = outputSum;
     }
     return;

--- a/catch/unit/cooperativeGrps/coalesced_groups_shfl_up_old.cc
+++ b/catch/unit/cooperativeGrps/coalesced_groups_shfl_up_old.cc
@@ -36,7 +36,7 @@ using namespace cooperative_groups;
 #define ASSERT_EQUAL(lhs, rhs) assert(lhs == rhs)
 #define WAVE_SIZE 32
 __device__ int prefix_sum_kernel(coalesced_group const& g, int val) {
-  int sz = g.size();
+  int sz = g.num_threads();
   for (int i = 1; i < sz; i <<= 1) {
     int temp = g.shfl_up(val, i);
 
@@ -73,7 +73,7 @@ __global__ void kernel_cg_group_partition_shfl_up(int* dPtr, unsigned int tileSz
     // Choose a leader thread to print the results
     if (threadBlockCGTy.thread_rank() == 0) {
       printf(" Creating %d groups, of tile size %d threads:\n\n",
-             (int)threadBlockCGTy.size() / tileSz, tileSz);
+             (int)threadBlockCGTy.num_threads() / tileSz, tileSz);
     }
 
     threadBlockCGTy.sync();

--- a/catch/unit/cooperativeGrps/grid_group.cc
+++ b/catch/unit/cooperativeGrps/grid_group.cc
@@ -32,7 +32,7 @@ THE SOFTWARE.
 namespace cg = cooperative_groups;
 
 static __global__ void grid_group_size_getter(unsigned int* sizes) {
-  sizes[thread_rank_in_grid()] = cg::this_grid().size();
+  sizes[thread_rank_in_grid()] = cg::this_grid().num_threads();
 }
 
 static __global__ void grid_group_thread_rank_getter(unsigned int* thread_ranks) {
@@ -64,7 +64,7 @@ static __global__ void sync_kernel(unsigned int* atomic_val, unsigned int *per_l
     // If the sync below fails, then the other threads may hit the
     // atomicInc instruction many times before the last thread ever gets to it.
     // If the sync works, then it will likely contain "total number of blocks"*iter
-    if (rank == (grid.size() - 1)) {
+    if (rank == (grid.num_threads() - 1)) {
       // The last wavefront should spin on this loop's atomic value
       // until all of the other wavefronts have incremented the
       // per-loop atomic and hit the grid.sync()

--- a/catch/unit/cooperativeGrps/hipCGCoalescedGroups_old.cc
+++ b/catch/unit/cooperativeGrps/hipCGCoalescedGroups_old.cc
@@ -42,7 +42,7 @@ __device__ int atomicAggInc(int *ptr) {
    int prev = 0;
    // elect the first active thread to perform atomic add
    if (g.thread_rank() == 0) {
-     prev = atomicAdd(ptr, g.size());
+     prev = atomicAdd(ptr, g.num_threads());
    }
    // broadcast previous value within the warp
    // and add each active thread’s rank to it
@@ -93,7 +93,7 @@ __global__ void filter_arr(int *dst, int *nres, const int *src, int n) {
 __device__ int reduction_kernel(coalesced_group g, int* x, int val) {
   int lane = g.thread_rank();
 
-  for (int i = g.size() / 2; i > 0; i /= 2) {
+  for (int i = g.num_threads() / 2; i > 0; i /= 2) {
     // use lds to store the temporary result
     x[lane] = val;
     // Ensure all the stores are completed.
@@ -145,9 +145,9 @@ __global__ void kernel_cg_coalesced_group_partition(unsigned int tileSz, int* re
 
     if (threadBlockCGTy.thread_rank() == 0) {
       printf(" Sum of all ranks 0..%d in coalesced_group is %d\n\n",
-             (int)threadBlockCGTy.size() - 1, outputSum);
+             (int)threadBlockCGTy.num_threads() - 1, outputSum);
       printf(" Creating %d groups, of tile size %d threads:\n\n",
-             (int)threadBlockCGTy.size() / tileSz, tileSz);
+             (int)threadBlockCGTy.num_threads() / tileSz, tileSz);
     }
 
     threadBlockCGTy.sync();
@@ -163,7 +163,7 @@ __global__ void kernel_cg_coalesced_group_partition(unsigned int tileSz, int* re
       printf(
           "   Sum of all ranks 0..%d in this tiledPartition group is %d. Corresponding parent thread rank"
           " obtained from meta_group_rank : %d and number of tiles created : %d\n",
-          tiledPartition.size() - 1, outputSum, tiledPartition.meta_group_rank(),
+          tiledPartition.num_threads() - 1, outputSum, tiledPartition.meta_group_rank(),
           tiledPartition.meta_group_size());
         result[input / (tileSz)] = outputSum;
     }
@@ -189,7 +189,7 @@ __global__ void kernel_coalesced_active_groups() {
     if (activeOdd.thread_rank() == 0) {
       printf(" ODD: Size of odd set of active threads is %d."
              " Corresponding parent thread_rank is %d.\n\n",
-               activeOdd.size(), threadBlockCGTy.thread_rank());
+               activeOdd.num_threads(), threadBlockCGTy.thread_rank());
     }
   }
   else { // Group all active even threads
@@ -198,7 +198,7 @@ __global__ void kernel_coalesced_active_groups() {
     if (activeEven.thread_rank() == 0) {
       printf(" EVEN: Size of even set of active threads is %d."
              " Corresponding parent thread_rank is %d.",
-               activeEven.size(), threadBlockCGTy.thread_rank());
+               activeEven.num_threads(), threadBlockCGTy.thread_rank());
     }
   }
   return;

--- a/catch/unit/cooperativeGrps/hipCGGridGroupType_old.cc
+++ b/catch/unit/cooperativeGrps/hipCGGridGroupType_old.cc
@@ -34,7 +34,7 @@ static __global__ void kernel_cg_grid_group_type(int* size_dev, int* thd_rank_de
   int gIdx = (blockIdx.x * blockDim.x) + threadIdx.x;
 
   // Test size
-  size_dev[gIdx] = gg.size();
+  size_dev[gIdx] = gg.num_threads();
 
   // Test thread_rank
   thd_rank_dev[gIdx] = gg.thread_rank();
@@ -57,7 +57,7 @@ static __global__ void kernel_cg_grid_group_type_via_base_type(int* size_dev, in
   int gIdx = (blockIdx.x * blockDim.x) + threadIdx.x;
 
   // Test size
-  size_dev[gIdx] = tg.size();
+  size_dev[gIdx] = tg.num_threads();
 
   // Test thread_rank
   thd_rank_dev[gIdx] = tg.thread_rank();
@@ -106,7 +106,7 @@ static __global__ void coop_kernel(unsigned int* first_array, unsigned int* seco
                                    unsigned int loops, unsigned int array_len) {
   cg::grid_group grid = cg::this_grid();
   unsigned int rank = grid.thread_rank();
-  unsigned int grid_size = grid.size();
+  unsigned int grid_size = grid.num_threads();
 
   for (int i = 0; i < loops; i++) {
     // The goal of this loop is to directly add in values from
@@ -145,7 +145,7 @@ static __global__ void test_kernel(unsigned int* atomic_val, unsigned int* array
     // If the barrier works, then it will likely contain some number
     // near "total number of blocks". It will be the last wavefront to
     // reach the atomicInc, but everyone will have only hit the atomic once.
-    if (rank == (grid.size() - 1)) {
+    if (rank == (grid.num_threads() - 1)) {
       long long time_diff = 0;
       long long last_clock = clock64();
       do {
@@ -185,7 +185,7 @@ __global__ void test_kernel_gfx11(unsigned int* atomic_val, unsigned int* array,
     // If the barrier works, then it will likely contain some number
     // near "total number of blocks". It will be the last wavefront to
     // reach the atomicInc, but everyone will have only hit the atomic once.
-    if (rank == (grid.size() - 1)) {
+    if (rank == (grid.num_threads() - 1)) {
       long long time_diff = 0;
       long long last_clock = clock_function();
       do {

--- a/catch/unit/cooperativeGrps/hipCGMultiGridGroupType_old.cc
+++ b/catch/unit/cooperativeGrps/hipCGMultiGridGroupType_old.cc
@@ -40,7 +40,7 @@ static __global__ void kernel_cg_multi_grid_group_type(int* grid_rank_dev, int* 
   grid_rank_dev[gIdx] = mg.grid_rank();
 
   // Test size
-  size_dev[gIdx] = mg.size();
+  size_dev[gIdx] = mg.num_threads();
 
   // Test thread_rank
   thd_rank_dev[gIdx] = mg.thread_rank();
@@ -81,7 +81,7 @@ static __global__ void kernel_cg_multi_grid_group_type_via_base_type(
   int gIdx = (blockIdx.x * blockDim.x) + threadIdx.x;
 
   // Test size
-  size_dev[gIdx] = tg.size();
+  size_dev[gIdx] = tg.num_threads();
 
   // Test thread_rank
   grid_rank_dev[gIdx] = cg::this_multi_grid().grid_rank();
@@ -174,7 +174,7 @@ __global__ void test_kernel(unsigned int* atomic_val, unsigned int* array, uint3
     // If the grid sync below fails, then the other threads may hit the
     // atomicInc instruction many times before the last thread ever gets to it.
     // If the sync works, then it will likely contain "total number of blocks"*iter
-    if (rank == (grid.size() - 1)) {
+    if (rank == (grid.num_threads() - 1)) {
       // The last wavefront should spin on this loop's atomic value
       // until all of the other wavefronts have incremented the
       // per-loop atomic and hit the grid.sync()
@@ -201,7 +201,7 @@ __global__ void test_kernel(unsigned int* atomic_val, unsigned int* array, uint3
     blocks_seen += grid_blocks;
 
     // Each grid updates its own counter
-    if (rank == (grid.size() - 1)) {
+    if (rank == (grid.num_threads() - 1)) {
       grid_values[grid_id] = atomicAdd(&grid_counters[grid_id], grid_id + 1);
     }
     mgrid.sync();

--- a/catch/unit/cooperativeGrps/hipCGThreadBlockTileTypeShfl_old.cc
+++ b/catch/unit/cooperativeGrps/hipCGThreadBlockTileTypeShfl_old.cc
@@ -31,7 +31,7 @@ enum class TiledGroupShflTests { shflDown, shflXor, shflUp };
 template <unsigned int tileSz>
 __device__ int reduction_kernel_shfl_down(cg::thread_block_tile<tileSz> const& g,
                                           volatile int val) {
-  int sz = g.size();
+  int sz = g.num_threads();
 
   for (int i = sz / 2; i > 0; i >>= 1) {
     val += g.shfl_down(val, i);
@@ -49,7 +49,7 @@ __device__ int reduction_kernel_shfl_down(cg::thread_block_tile<tileSz> const& g
 
 template <unsigned int tileSz>
 __device__ int reduction_kernel_shfl_xor(cg::thread_block_tile<tileSz> const& g, int val) {
-  int sz = g.size();
+  int sz = g.num_threads();
 
   for (int i = sz / 2; i > 0; i >>= 1) {
     val += g.shfl_xor(val, i);
@@ -67,7 +67,7 @@ __device__ int reduction_kernel_shfl_xor(cg::thread_block_tile<tileSz> const& g,
 
 template <unsigned int tileSz>
 __device__ int prefix_sum_kernel(cg::thread_block_tile<tileSz> const& g, volatile int val) {
-  int sz = g.size();
+  int sz = g.num_threads();
 #pragma unroll
   for (int i = 1; i < sz; i <<= 1) {
     int temp = g.shfl_up(val, i);
@@ -88,7 +88,7 @@ static __global__ void kernel_cg_group_partition_static(int* result,
   // Choose a leader thread to print the results
   if (thread_block_CG_ty.thread_rank() == 0) {
     printf(" Creating %d groups, of tile size %d threads:\n\n",
-           (int)thread_block_CG_ty.size() / tile_size, tile_size);
+           (int)thread_block_CG_ty.num_threads() / tile_size, tile_size);
   }
 
   thread_block_CG_ty.sync();
@@ -110,7 +110,7 @@ static __global__ void kernel_cg_group_partition_static(int* result,
   }
 
   if (tiled_part.thread_rank() == 0 && shfl_test != TiledGroupShflTests::shflUp) {
-    printf("   Sum of all ranks 0..%d in this tiled_part group is %d\n", tiled_part.size() - 1,
+    printf("   Sum of all ranks 0..%d in this tiled_part group is %d\n", tiled_part.num_threads() - 1,
            output_sum);
     result[thread_block_CG_ty.thread_rank() / (tile_size)] = output_sum;
   }

--- a/catch/unit/cooperativeGrps/hipCGThreadBlockType_old.cc
+++ b/catch/unit/cooperativeGrps/hipCGThreadBlockType_old.cc
@@ -34,7 +34,7 @@ static __global__ void kernel_cg_thread_block_type(int* size_dev, int* thd_rank_
   cg::thread_block tb = cg::this_thread_block();
   int gIdx = (blockIdx.x * blockDim.x) + threadIdx.x;
   // Test size
-  size_dev[gIdx] = tb.size();
+  size_dev[gIdx] = tb.num_threads();
 
   // Test thread_rank
   thd_rank_dev[gIdx] = tb.thread_rank();
@@ -64,7 +64,7 @@ static __global__ void kernel_cg_thread_block_type_via_base_type(int* size_dev, 
   int gIdx = (blockIdx.x * blockDim.x) + threadIdx.x;
 
   // Test size
-  size_dev[gIdx] = tg.size();
+  size_dev[gIdx] = tg.num_threads();
 
   // Test thread_rank
   thd_rank_dev[gIdx] = tg.thread_rank();

--- a/catch/unit/cooperativeGrps/hipCGTiledPartitionType_old.cc
+++ b/catch/unit/cooperativeGrps/hipCGTiledPartitionType_old.cc
@@ -49,7 +49,7 @@ namespace cg = cooperative_groups;
 __device__ int reduction_kernel(cg::thread_group g, int* x, int val) {
   int lane = g.thread_rank();
 
-  for (int i = g.size() / 2; i > 0; i /= 2) {
+  for (int i = g.num_threads() / 2; i > 0; i /= 2) {
     // use lds to store the temporary result
     x[lane] = val;
     // Ensure all the stores are completed.
@@ -94,15 +94,15 @@ __global__ void kernel_cg_group_partition_static(int* result, bool is_global_mem
   // input to reduction, for each thread, is its' rank in the group
   input = thread_block_CG_ty.thread_rank();
 
-  expected_output = (thread_block_CG_ty.size() - 1) * thread_block_CG_ty.size() / 2;
+  expected_output = (thread_block_CG_ty.num_threads() - 1) * thread_block_CG_ty.num_threads() / 2;
 
   output_sum = reduction_kernel(thread_block_CG_ty, workspace, input);
 
   if (thread_block_CG_ty.thread_rank() == 0) {
     printf(" Sum of all ranks 0..%d in threadBlockCooperativeGroup is %d (expected %d)\n\n",
-           (int)thread_block_CG_ty.size() - 1, output_sum, expected_output);
+           (int)thread_block_CG_ty.num_threads() - 1, output_sum, expected_output);
     printf(" Creating %d groups, of tile size %d threads:\n\n",
-           (int)thread_block_CG_ty.size() / tile_size, tile_size);
+           (int)thread_block_CG_ty.num_threads() / tile_size, tile_size);
   }
 
   thread_block_CG_ty.sync();
@@ -119,7 +119,7 @@ __global__ void kernel_cg_group_partition_static(int* result, bool is_global_mem
         "   Sum of all ranks 0..%d in this tiledPartition group is %d. Corresponding parent thread "
         "rank: via meta_group_rank : %d and the total number of groups created when partitioned : "
         "%d\n",
-        tiled_part.size() - 1, output_sum, tiled_part.meta_group_rank(),
+        tiled_part.num_threads() - 1, output_sum, tiled_part.meta_group_rank(),
         tiled_part.meta_group_size());
     result[input / (tile_size)] = output_sum;
   }
@@ -149,9 +149,9 @@ __global__ void kernel_cg_group_partition_dynamic(unsigned int tile_size, int* r
 
   if (thread_block_CG_ty.thread_rank() == 0) {
     printf("\n\n\n Sum of all ranks 0..%d in threadBlockCooperativeGroup is %d\n\n",
-           (int)thread_block_CG_ty.size() - 1, output_sum);
+           (int)thread_block_CG_ty.num_threads() - 1, output_sum);
     printf(" Creating %d groups, of tile size %d threads:\n\n",
-           (int)thread_block_CG_ty.size() / tile_size, tile_size);
+           (int)thread_block_CG_ty.num_threads() / tile_size, tile_size);
   }
 
   thread_block_CG_ty.sync();
@@ -167,7 +167,7 @@ __global__ void kernel_cg_group_partition_dynamic(unsigned int tile_size, int* r
     printf(
         "   Sum of all ranks 0..%d in this tiledPartition group is %d. Corresponding parent thread "
         "rank: %d\n",
-        static_cast<int>(tiled_part.size()) - 1, output_sum, input);
+        static_cast<int>(tiled_part.num_threads()) - 1, output_sum, input);
     result[input / (tile_size)] = output_sum;
   }
   return;

--- a/catch/unit/cooperativeGrps/multi_grid_group.cc
+++ b/catch/unit/cooperativeGrps/multi_grid_group.cc
@@ -35,7 +35,7 @@ namespace cg = cooperative_groups;
 template <typename BaseType = cg::multi_grid_group>
 static __global__ void multi_grid_group_size_getter(unsigned int* sizes) {
   const BaseType group = cg::this_multi_grid();
-  sizes[thread_rank_in_grid()] = group.size();
+  sizes[thread_rank_in_grid()] = group.num_threads();
 }
 
 template <typename BaseType = cg::multi_grid_group>
@@ -79,7 +79,7 @@ static __global__ void sync_kernel(unsigned int* atomic_val, unsigned int* globa
     // If the sync below fails, then the other threads may hit the
     // atomicInc instruction many times before the last thread ever gets to it.
     // If the sync works, then it will likely contain "total number of blocks"*i
-    if (rank == (grid.size() - 1)) {
+    if (rank == (grid.num_threads() - 1)) {
       busy_wait(100000);
     }
     if (threadIdx.x == blockDim.x - 1 && threadIdx.y == blockDim.y - 1 &&
@@ -90,14 +90,14 @@ static __global__ void sync_kernel(unsigned int* atomic_val, unsigned int* globa
 
     // Make the last thread in the entire multi-grid run way behind
     // everyone else.
-    if (global_rank == (mgrid.size() - 1)) {
+    if (global_rank == (mgrid.num_threads() - 1)) {
       busy_wait(100000);
     }
     // During even iterations, add into your own array entry
     // During odd iterations, add into next array entry
     unsigned grid_rank = mgrid.grid_rank();
     unsigned inter_gpu_offset = (grid_rank + 1) % mgrid.num_grids();
-    if (rank == (grid.size() - 1)) {
+    if (rank == (grid.num_threads() - 1)) {
       if (i % 2 == 0) {
         global_array[grid_rank] += 2;
       } else {

--- a/catch/unit/cooperativeGrps/thread_block.cc
+++ b/catch/unit/cooperativeGrps/thread_block.cc
@@ -39,7 +39,7 @@ namespace cg = cooperative_groups;
 template <typename BaseType = cg::thread_block>
 static __global__ void thread_block_size_getter(unsigned int* sizes) {
   const BaseType group = cg::this_thread_block();
-  sizes[thread_rank_in_grid()] = group.size();
+  sizes[thread_rank_in_grid()] = group.num_threads();
 }
 
 template <typename BaseType = cg::thread_block>
@@ -260,9 +260,9 @@ __global__ void thread_block_sync_check(T* global_data, unsigned int* wait_modif
   data[tid] = tid % divisor;
   block.sync();
   bool valid = true;
-  for (auto i = 0; i < block.size(); ++i) {
-    const auto offset = block.size() + read_offset;
-    const auto expected = (tid + offset + i) % block.size();
+  for (auto i = 0; i < block.num_threads(); ++i) {
+    const auto offset = block.num_threads() + read_offset;
+    const auto expected = (tid + offset + i) % block.num_threads();
     if (!(valid &= (data[expected] == expected % divisor))) {
       break;
     }

--- a/catch/unit/cooperativeGrps/thread_block_tile.cc
+++ b/catch/unit/cooperativeGrps/thread_block_tile.cc
@@ -44,10 +44,10 @@ template <bool dynamic, unsigned int tile_size>
 __global__ void thread_block_partition_size_getter(unsigned int* sizes) {
   const auto group = cg::this_thread_block();
   if constexpr (dynamic) {
-    sizes[thread_rank_in_grid()] = cg::tiled_partition(group, tile_size).size();
+    sizes[thread_rank_in_grid()] = cg::tiled_partition(group, tile_size).num_threads();
   } else {
     cg::thread_block_tile<tile_size> tiled_partition = cg::tiled_partition<tile_size>(group);
-    sizes[thread_rank_in_grid()] = tiled_partition.size();
+    sizes[thread_rank_in_grid()] = tiled_partition.num_threads();
   }
 }
 
@@ -421,15 +421,15 @@ __global__ void block_tile_sync_check(T* global_data, unsigned int* wait_modifie
   const cg::thread_block_tile<tile_size> partition =
       cg::tiled_partition<tile_size>(cg::this_thread_block());
 
-  const auto data_idx = [&block](unsigned int i) { return use_global ? i : (i % block.size()); };
+  const auto data_idx = [&block](unsigned int i) { return use_global ? i : (i % block.num_threads()); };
 
-  const auto partitions_in_block = (block.size() + partition.size() - 1) / partition.size();
-  const auto partition_rank = block.thread_rank() / partition.size();
-  const auto tail = partitions_in_block * partition.size() - block.size();
-  const auto window_size = partition.size() - tail * (partition_rank == partitions_in_block - 1);
+  const auto partitions_in_block = (block.num_threads() + partition.num_threads() - 1) / partition.num_threads();
+  const auto partition_rank = block.thread_rank() / partition.num_threads();
+  const auto tail = partitions_in_block * partition.num_threads() - block.num_threads();
+  const auto window_size = partition.num_threads() - tail * (partition_rank == partitions_in_block - 1);
 
-  const auto block_base_idx = tid / block.size() * block.size();
-  const auto tile_base_idx = block_base_idx + partition_rank * partition.size();
+  const auto block_base_idx = tid / block.num_threads() * block.num_threads();
+  const auto tile_base_idx = block_base_idx + partition_rank * partition.num_threads();
 
   const auto wait_modifier = wait_modifiers[tid];
   busy_wait(wait_modifier);

--- a/catch/unit/device_memory/memcpy.cc
+++ b/catch/unit/device_memory/memcpy.cc
@@ -41,7 +41,7 @@ __global__ void memcpy_at_once_kernel(T* dst, T* src, const size_t alloc_size) {
 
 template <typename T> __global__ void memcpy_one_by_one_kernel(T* dst, T* src, const size_t N) {
   const auto tid = cooperative_groups::this_grid().thread_rank();
-  const auto stride = cooperative_groups::this_grid().size();
+  const auto stride = cooperative_groups::this_grid().num_threads();
 
   for (auto i = tid; i < N; i += stride) {
     memcpy(dst + tid, src + tid, sizeof(T));

--- a/catch/unit/device_memory/memset.cc
+++ b/catch/unit/device_memory/memset.cc
@@ -41,7 +41,7 @@ __global__ void memset_at_once_kernel(T* dst, int value, const size_t alloc_size
 
 template <typename T> __global__ void memset_one_by_one_kernel(T* dst, int value, const size_t N) {
   const auto tid = cooperative_groups::this_grid().thread_rank();
-  const auto stride = cooperative_groups::this_grid().size();
+  const auto stride = cooperative_groups::this_grid().num_threads();
 
   for (auto i = tid; i < N; i += stride) {
     memset(dst + tid, value, sizeof(T));


### PR DESCRIPTION
…s function

Adapt the tests to use the cooperative_groups num_threads function instead of the size function.
The size function is deprecated in cooperative_groups.

## Associated JIRA ticket number/Github issue number
SWDEV-533232

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## What were the changes?

Adapt the tests to use the cooperative_groups num_threads function instead of the size function.
The size function is deprecated in cooperative_groups.

## Why are these changes needed?

The size function is deprecated in cooperative_groups.
Switch the tests to use num_threads API instead.

## Updated CHANGELOG?

<!-- Needed for Release updates for a ROCm release. -->

- [ ] Yes
- [x] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [x] No, Does not apply to this PR.

## Additional Checks

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally.
- [x] Any dependent changes have been merged.
