### PR TITLE
SWDEV-505930 - Avoid static initialization of ModuleGuard

### DIFF
--- a/catch/unit/module/CMakeLists.txt
+++ b/catch/unit/module/CMakeLists.txt
@@ -85,8 +85,13 @@ if(HIP_PLATFORM MATCHES "amd")
 set(TEST_SRC
     ${TEST_SRC}
     hipExtModuleLaunchKernel.cc
-    hipHccModuleLaunchKernel.cc
-    hipGetProcAddressModuleApis.cc)
+    hipHccModuleLaunchKernel.cc)
+
+if(BUILD_SHARED_LIBS)
+  set(TEST_SRC
+      ${TEST_SRC}
+      hipGetProcAddressModuleApis.cc)
+endif()
 
 add_custom_target(empty_module.code
                   COMMAND ${CMAKE_CXX_COMPILER} --genco ${OFFLOAD_ARCH_STR}

--- a/catch/unit/module/hipExtModuleLaunchKernel.cc
+++ b/catch/unit/module/hipExtModuleLaunchKernel.cc
@@ -261,13 +261,12 @@ TEST_CASE("Unit_hipExtModuleLaunchKernel_UniformWorkGroup") {
 
 TEST_CASE("Unit_hipExtModuleLaunchKernel_Positive_Parameters") {
   ModuleLaunchKernelPositiveParameters<hipExtModuleLaunchKernel>();
-
+  auto mg = ModuleGuard::InitModule("launch_kernel_module.code");
   SECTION("Pass only start event") {
     hipEvent_t start_event = nullptr;
     HIP_CHECK(hipEventCreate(&start_event));
     const auto kernel = GetKernel(mg.module(), "NOPKernel");
-    HIP_CHECK(hipExtModuleLaunchKernel(kernel, 1, 1, 1, 1, 1, 1, 0, nullptr,
-                                       nullptr, nullptr,
+    HIP_CHECK(hipExtModuleLaunchKernel(kernel, 1, 1, 1, 1, 1, 1, 0, nullptr, nullptr, nullptr,
                                        start_event, nullptr));
     HIP_CHECK(hipDeviceSynchronize());
     HIP_CHECK(hipEventQuery(start_event));

--- a/catch/unit/module/hipModuleLaunchCooperativeKernel.cc
+++ b/catch/unit/module/hipModuleLaunchCooperativeKernel.cc
@@ -50,6 +50,7 @@ THE SOFTWARE.
  *  - HIP_VERSION >= 5.5
  */
 TEST_CASE("Unit_hipModuleLaunchCooperativeKernel_Positive_Basic") {
+  auto mg = ModuleGuard::InitModule("launch_kernel_module.code");
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
     HipTest::HIP_SKIP_TEST("CooperativeLaunch not supported");
     return;
@@ -89,6 +90,7 @@ TEST_CASE("Unit_hipModuleLaunchCooperativeKernel_Positive_Basic") {
  *  - HIP_VERSION >= 5.5
  */
 TEST_CASE("Unit_hipModuleLaunchCooperativeKernel_Positive_Parameters") {
+  auto mg = ModuleGuard::InitModule("launch_kernel_module.code");
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
     HipTest::HIP_SKIP_TEST("CooperativeLaunch not supported");
     return;
@@ -124,6 +126,7 @@ TEST_CASE("Unit_hipModuleLaunchCooperativeKernel_Positive_Parameters") {
  *  - HIP_VERSION >= 5.5
  */
 TEST_CASE("Unit_hipModuleLaunchCooperativeKernel_Negative_Parameters") {
+  auto mg = ModuleGuard::InitModule("launch_kernel_module.code");
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
     HipTest::HIP_SKIP_TEST("CooperativeLaunch not supported");
     return;

--- a/catch/unit/module/hipModuleLaunchCooperativeKernelMultiDevice.cc
+++ b/catch/unit/module/hipModuleLaunchCooperativeKernelMultiDevice.cc
@@ -49,6 +49,7 @@ THE SOFTWARE.
  *  - HIP_VERSION >= 5.5
  */
 TEST_CASE("Unit_hipModuleLaunchCooperativeKernelMultiDevice_Positive_Basic") {
+  auto mg = ModuleGuard::InitModule("launch_kernel_module.code");
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
     HipTest::HIP_SKIP_TEST("CooperativeLaunch not supported");
     return;
@@ -106,6 +107,7 @@ TEST_CASE("Unit_hipModuleLaunchCooperativeKernelMultiDevice_Positive_Basic") {
  *  - HIP_VERSION >= 5.5
  */
 TEST_CASE("Unit_hipModuleLaunchCooperativeKernelMultiDevice_Negative_Parameters") {
+  auto mg = ModuleGuard::InitModule("launch_kernel_module.code");
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
     HipTest::HIP_SKIP_TEST("CooperativeLaunch not supported");
     return;
@@ -229,6 +231,7 @@ TEST_CASE("Unit_hipModuleLaunchCooperativeKernelMultiDevice_Negative_Parameters"
  *  - HIP_VERSION >= 5.5
  */
 TEST_CASE("Unit_hipModuleLaunchCooperativeKernelMultiDevice_Negative_MultiKernelSameDevice") {
+  auto mg = ModuleGuard::InitModule("launch_kernel_module.code");
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
     HipTest::HIP_SKIP_TEST("CooperativeLaunch not supported");
     return;

--- a/catch/unit/module/hip_module_common.cc
+++ b/catch/unit/module/hip_module_common.cc
@@ -33,6 +33,11 @@ ModuleGuard ModuleGuard::LoadModule(const char* fname) {
   return ModuleGuard{module};
 }
 
+ModuleGuard ModuleGuard::InitModule(const char* fname) {
+  HIP_CHECK(hipFree(nullptr));
+  return LoadModule(fname);
+}
+
 ModuleGuard ModuleGuard::LoadModuleDataFile(const char* fname) {
   const auto loaded_module = LoadModuleIntoBuffer(fname);
   hipModule_t module = nullptr;

--- a/catch/unit/module/hip_module_common.hh
+++ b/catch/unit/module/hip_module_common.hh
@@ -34,6 +34,8 @@ class ModuleGuard {
 
   static ModuleGuard LoadModule(const char* fname);
 
+  static ModuleGuard InitModule(const char* fname);
+
   static ModuleGuard LoadModuleDataFile(const char* fname);
 
   static ModuleGuard LoadModuleDataRTC(const char* code);

--- a/catch/unit/module/hip_module_launch_kernel_common.hh
+++ b/catch/unit/module/hip_module_launch_kernel_common.hh
@@ -27,18 +27,12 @@ THE SOFTWARE.
 #include <resource_guards.hh>
 #include <utils.hh>
 
-inline ModuleGuard InitModule() {
-  HIP_CHECK(hipFree(nullptr));
-  return ModuleGuard::LoadModule("launch_kernel_module.code");
-}
-
-inline ModuleGuard mg{InitModule()};
-
 using ExtModuleLaunchKernelSig = hipError_t(hipFunction_t, uint32_t, uint32_t, uint32_t, uint32_t,
                                             uint32_t, uint32_t, size_t, hipStream_t, void**, void**,
                                             hipEvent_t, hipEvent_t, uint32_t);
 
 template <ExtModuleLaunchKernelSig* func> void ModuleLaunchKernelPositiveBasic() {
+  auto mg = ModuleGuard::InitModule("launch_kernel_module.code");
   SECTION("Kernel with no arguments") {
     hipFunction_t f = GetKernel(mg.module(), "NOPKernel");
     HIP_CHECK(func(f, 1, 1, 1, 1, 1, 1, 0, nullptr, nullptr, nullptr, nullptr, nullptr, 0u));
@@ -81,6 +75,7 @@ template <ExtModuleLaunchKernelSig* func> void ModuleLaunchKernelPositiveParamet
   const auto LaunchNOPKernel = [=](unsigned int gridDimX, unsigned int gridDimY,
                                    unsigned int gridDimZ, unsigned int blockDimX,
                                    unsigned int blockDimY, unsigned int blockDimZ) {
+    auto mg = ModuleGuard::InitModule("launch_kernel_module.code");
     hipFunction_t f = GetKernel(mg.module(), "NOPKernel");
     HIP_CHECK(func(f, gridDimX, gridDimY, gridDimZ, blockDimX, blockDimY, blockDimZ, 0, nullptr,
                    nullptr, nullptr, nullptr, nullptr, 0u));
@@ -120,6 +115,7 @@ template <ExtModuleLaunchKernelSig* func> void ModuleLaunchKernelPositiveParamet
 
 template <ExtModuleLaunchKernelSig* func> void ModuleLaunchKernelNegativeParameters(
                                                            bool extLaunch = false) {
+  auto mg = ModuleGuard::InitModule("launch_kernel_module.code");
   hipFunction_t f = GetKernel(mg.module(), "NOPKernel");
   hipError_t expectedErrorLaunchParam = (extLaunch == true) ? hipErrorInvalidConfiguration
                                                              : hipErrorInvalidValue;
@@ -213,6 +209,7 @@ template <ExtModuleLaunchKernelSig* func> void ModuleLaunchKernelNegativeParamet
   }
 
   SECTION("Passing kernel_args and extra simultaneously") {
+    auto mg = ModuleGuard::InitModule("launch_kernel_module.code");
     hipFunction_t f = GetKernel(mg.module(), "Kernel42");
     LinearAllocGuard<int> result_dev(LinearAllocs::hipMalloc, sizeof(int));
     int* result_ptr = result_dev.ptr();
@@ -230,6 +227,7 @@ template <ExtModuleLaunchKernelSig* func> void ModuleLaunchKernelNegativeParamet
   }
 
   SECTION("Invalid extra") {
+    auto mg = ModuleGuard::InitModule("launch_kernel_module.code");
     hipFunction_t f = GetKernel(mg.module(), "Kernel42");
     void* extra[0] = {};
     HIP_CHECK_ERROR(func(f, 1, 1, 1, 1, 1, 1, 0, nullptr, nullptr, extra, nullptr, nullptr, 0u),


### PR DESCRIPTION
## Associated JIRA ticket number/Github issue number
<!-- For example: "Closes #1234" or "Fixes SWDEV-123456" -->
Fixes SWDEV-505930

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## What were the changes?
Avoid static initialization of ModuleGuard. This change also disables hipGetProcAddress tests that are not supported on static build.

<!-- Please give a short summary of the change. -->

## Why are these changes needed?
This is to prevent calling catch2 macros from outside catch2 TEST_CASE that can lead to undefined behavior.

<!-- Please explain the motivation behind the change and why this solves the given problem. -->

## Updated CHANGELOG?

<!-- Needed for Release updates for a ROCm release. -->

- [ ] Yes
- [x] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [x] No, Does not apply to this PR.

## Additional Checks

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally.
- [x] Any dependent changes have been merged.




