### PR TITLE
SWDEV-500337 - Add basic multi_proc tests for Windows

### DIFF
--- a/catch/multiproc/deviceAllocationMproc.cc
+++ b/catch/multiproc/deviceAllocationMproc.cc
@@ -345,4 +345,4 @@ TEST_CASE("Unit_deviceAllocation_NewDelete_MultProcess") {
   REQUIRE(res == true);
 }
 
-#endif
+#endif //__linux__

--- a/catch/multiproc/hipDeviceGetPCIBusIdMproc.cc
+++ b/catch/multiproc/hipDeviceGetPCIBusIdMproc.cc
@@ -255,4 +255,4 @@ TEST_CASE("Unit_hipDeviceGetPCIBusId_CheckPciBusIDWithLspci") {
 
   REQUIRE(deviceMatchCount == deviceCount);
 }
-#endif
+#endif //__linux__

--- a/catch/multiproc/hipDeviceTotalMemMproc.cc
+++ b/catch/multiproc/hipDeviceTotalMemMproc.cc
@@ -174,4 +174,4 @@ TEST_CASE("Unit_hipDeviceTotalMem_MaskedDevices") {
  * @}
  */
 
-#endif
+#endif //__linux__

--- a/catch/multiproc/hipGetDeviceAttributeMproc.cc
+++ b/catch/multiproc/hipGetDeviceAttributeMproc.cc
@@ -161,4 +161,4 @@ TEST_CASE("Unit_hipDeviceGetAttribute_MaskedDevices") {
     SUCCEED("Not enough GPUs to run the masked GPU tests");
   }
 }
-#endif
+#endif //__linux__

--- a/catch/multiproc/hipGetDeviceCountMproc.cc
+++ b/catch/multiproc/hipGetDeviceCountMproc.cc
@@ -26,9 +26,19 @@ THE SOFTWARE.
 #ifdef __linux__
 #include <unistd.h>
 #include <sys/wait.h>
+#endif // __linux__
 
 #define MAX_SIZE 30
 #define VISIBLE_DEVICE 0
+
+#ifdef _WIN32
+static int setenv(const char* name, const char* value, int overwrite) {
+  REQUIRE(overwrite == 1);
+  return _putenv_s(name, value);
+}
+
+static int unsetenv(const char* name) { return _putenv_s(name, ""); }
+#endif // _WIN32
 
 /**
  * Validate behavior of hipGetDeviceCount for masked devices.
@@ -51,4 +61,3 @@ TEST_CASE("Unit_hipGetDeviceCount_MaskedDevices") {
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   REQUIRE(numDevices == 1);
 }
-#endif

--- a/catch/multiproc/hipIpcEventHandle.cc
+++ b/catch/multiproc/hipIpcEventHandle.cc
@@ -437,4 +437,4 @@ TEST_CASE("Unit_hipIpcEventHandle_ParameterValidation") {
  * @}
  */
 
-#endif
+#endif // __linux__

--- a/catch/multiproc/hipIpcMemAccessTest.cc
+++ b/catch/multiproc/hipIpcMemAccessTest.cc
@@ -182,6 +182,8 @@ TEST_CASE("Unit_hipIpcMemAccess_Semaphores") {
                            A_h, nullptr, C_h, false);
 }
 
+#endif // __linux__
+
 /**
  * Test Description
  * ------------------------
@@ -278,4 +280,3 @@ TEST_CASE("Unit_hipIpcMemAccess_ParameterValidation") {
  * @}
  */
 
-#endif

--- a/catch/multiproc/hipMemCoherencyTstMProc.cc
+++ b/catch/multiproc/hipMemCoherencyTstMProc.cc
@@ -591,4 +591,4 @@ TEST_CASE("Unit_hipHostMalloc_WthEnv1Flg3") {
   }
 }
 #endif
-#endif
+#endif // __linux__

--- a/catch/multiproc/hipMemGetInfoMProc.cc
+++ b/catch/multiproc/hipMemGetInfoMProc.cc
@@ -390,4 +390,4 @@ TEST_CASE("Unit_hipMemGetInfo_VerifyHiddenFreeMemForAllGpu") {
   }
 }
 #endif
-#endif
+#endif // __linux__


### PR DESCRIPTION
Adds basic multi processes tests for windows. This silences errors on windows related to Catch2 building executables with no tests.