### PR TITLE
SWDEV-465214 - Change carveout tests; value shall be ignored on AMD

### DIFF
--- a/catch/hipTestMain/config/config_amd_linux
+++ b/catch/hipTestMain/config/config_amd_linux
@@ -27,7 +27,6 @@
         "Unit_hipFuncSetCacheConfig_Positive_Basic",
         "Unit_hipFuncSetCacheConfig_Negative_Parameters",
         "Unit_hipFuncSetSharedMemConfig_Positive_Basic",
-        "Unit_hipFuncSetAttribute_Positive_PreferredSharedMemoryCarveout",
         "NOTE: The following test is disabled due to defect - EXSWHTEC-241",
         "NOTE: The following test is disabled due to defect - EXSWHTEC-242",
         "Unit_hipFuncGetAttributes_Positive_Basic",

--- a/catch/hipTestMain/config/config_amd_windows
+++ b/catch/hipTestMain/config/config_amd_windows
@@ -107,7 +107,6 @@
         "Unit_hipFuncSetCacheConfig_Positive_Basic",
         "Unit_hipFuncSetCacheConfig_Negative_Parameters",
         "Unit_hipFuncSetSharedMemConfig_Positive_Basic",
-        "Unit_hipFuncSetAttribute_Positive_PreferredSharedMemoryCarveout",
         "Unit_hipEventCreateWithFlags_DisableSystemFence_HstVisMem",
         "Unit_hipEventCreateWithFlags_DefaultFlg_HstVisMem",
         "Unit_hipEventCreateWithFlags_DisableSystemFence_NonCohHstMem",

--- a/catch/hipTestMain/config/config_amd_wsl.json
+++ b/catch/hipTestMain/config/config_amd_wsl.json
@@ -95,7 +95,6 @@
         "Unit_hipFuncSetCacheConfig_Positive_Basic",
         "Unit_hipFuncSetCacheConfig_Negative_Parameters",
         "Unit_hipFuncSetSharedMemConfig_Positive_Basic",
-        "Unit_hipFuncSetAttribute_Positive_PreferredSharedMemoryCarveout",
         "Unit_hipEventCreateWithFlags_DisableSystemFence_HstVisMem",
         "Unit_hipEventCreateWithFlags_DefaultFlg_HstVisMem",
         "Unit_hipEventCreateWithFlags_DisableSystemFence_NonCohHstMem",

--- a/catch/unit/executionControl/CMakeLists.txt
+++ b/catch/unit/executionControl/CMakeLists.txt
@@ -4,6 +4,7 @@ set(TEST_SRC
     hipLaunchKernel.cc
     hipLaunchCooperativeKernel.cc
     hipLaunchCooperativeKernelMultiDevice.cc
+    hipFuncSetAttribute.cc
 )
 
 if(HIP_PLATFORM MATCHES "amd")
@@ -18,7 +19,7 @@ else()
     set(TEST_SRC ${TEST_SRC}
         hipFuncSetCacheConfig.cc
         hipFuncSetSharedMemConfig.cc
-        hipFuncSetAttribute.cc
+        
     )
 endif()
 

--- a/catch/unit/executionControl/hipFuncSetAttribute.cc
+++ b/catch/unit/executionControl/hipFuncSetAttribute.cc
@@ -68,13 +68,24 @@ TEST_CASE("Unit_hipFuncSetAttribute_Positive_MaxDynamicSharedMemorySize") {
  *  - HIP_VERSION >= 5.2
  */
 TEST_CASE("Unit_hipFuncSetAttribute_Positive_PreferredSharedMemoryCarveout") {
+#if (HT_AMD == 1)
+  // on AMD, it is completely ignored, i.e. no effect in L1/shared distribution; but
+  // also when queried again, its value must match the old value
+  hipFuncAttributes old_attributes, new_attributes;
+
+  HIP_CHECK(hipFuncGetAttributes(&old_attributes, reinterpret_cast<void*>(kernel)));
   HIP_CHECK(hipFuncSetAttribute(reinterpret_cast<void*>(kernel),
                                 hipFuncAttributePreferredSharedMemoryCarveout, 50));
+  HIP_CHECK(hipFuncGetAttributes(&new_attributes, reinterpret_cast<void*>(kernel)));
+  REQUIRE(old_attributes.preferredShmemCarveout == new_attributes.preferredShmemCarveout);
+#else
+  hipFuncAttributes new_attributes;
 
-  hipFuncAttributes attributes;
-  HIP_CHECK(hipFuncGetAttributes(&attributes, reinterpret_cast<void*>(kernel)));
-
-  REQUIRE(attributes.preferredShmemCarveout == 50);
+  HIP_CHECK(hipFuncSetAttribute(reinterpret_cast<void*>(kernel),
+                                hipFuncAttributePreferredSharedMemoryCarveout, 50));
+  HIP_CHECK(hipFuncGetAttributes(&new_attributes, reinterpret_cast<void*>(kernel)));
+  REQUIRE(new_attributes.preferredShmemCarveout == 50);
+#endif
 }
 
 /**
@@ -203,70 +214,6 @@ TEST_CASE("Unit_hipFuncSetAttribute_Negative_Parameters") {
                                         hipFuncAttributePreferredSharedMemoryCarveout, 101),
                     hipErrorInvalidValue);
   }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Sets `hipFuncAttributeMaxDynamicSharedMemorySize` to the non-supported value
- *    - Expected output: return `hipErrorNotSupported`
- * Test source
- * ------------------------
- *  - unit/executionControl/hipFuncSetAttribute.cc
- * Test requirements
- * ------------------------
- *  - Platform specific (AMD)
- *  - HIP_VERSION >= 5.2
- */
-TEST_CASE("Unit_hipFuncSetAttribute_Positive_MaxDynamicSharedMemorySize_Not_Supported") {
-#if HT_NVIDIA
-  HipTest::HIP_SKIP_TEST("This is an AMD specific test");
-  return;
-#endif
-
-  hipFuncAttributes old_attributes;
-  HIP_CHECK(hipFuncGetAttributes(&old_attributes, reinterpret_cast<void*>(kernel)));
-
-  HIP_CHECK_ERROR(hipFuncSetAttribute(reinterpret_cast<void*>(kernel),
-                                      hipFuncAttributeMaxDynamicSharedMemorySize, 1024),
-                  hipErrorNotSupported);
-
-  hipFuncAttributes new_attributes;
-  HIP_CHECK(hipFuncGetAttributes(&new_attributes, reinterpret_cast<void*>(kernel)));
-
-  REQUIRE(old_attributes.maxDynamicSharedSizeBytes == new_attributes.maxDynamicSharedSizeBytes);
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Sets `hipFuncAttributePreferredSharedMemoryCarveout` to the non-supported value
- *    - Expected output: return `hipErrorNotSupported`
- * Test source
- * ------------------------
- *  - unit/executionControl/hipFuncSetAttribute.cc
- * Test requirements
- * ------------------------
- *  - Platform specific (AMD)
- *  - HIP_VERSION >= 5.2
- */
-TEST_CASE("Unit_hipFuncSetAttribute_Positive_PreferredSharedMemoryCarveout_Not_Supported") {
-#if HT_NVIDIA
-  HipTest::HIP_SKIP_TEST("This is an AMD specific test");
-  return;
-#endif
-
-  hipFuncAttributes old_attributes;
-  HIP_CHECK(hipFuncGetAttributes(&old_attributes, reinterpret_cast<void*>(kernel)));
-
-  HIP_CHECK_ERROR(hipFuncSetAttribute(reinterpret_cast<void*>(kernel),
-                                      hipFuncAttributePreferredSharedMemoryCarveout, 50),
-                  hipErrorNotSupported);
-
-  hipFuncAttributes new_attributes;
-  HIP_CHECK(hipFuncGetAttributes(&new_attributes, reinterpret_cast<void*>(kernel)));
-
-  REQUIRE(old_attributes.preferredShmemCarveout == new_attributes.preferredShmemCarveout);
 }
 
 /**


### PR DESCRIPTION
This PR recreates Gerrit's patch: https://gerrit-git.amd.com/c/compute/ec/hip-tests/+/1193797

Pending conversation from that patch:

Maneesh Gupta
I guess another way to implement this test would be to have the REQUIRE line only in the nv case, while in the amd case we would do the set, but not the REQUIRE.

Gerardo Hernandez
If we do the setAttribute(), but not the REQUIRE() on AMD, as you say, it would not demonstrate that the value being passed to hipFuncSetAttribute() is ignored on AMD. i.e. in the test I am demonstrating that the value stays the same; hence proving it is ignored.
Is that not the right thing to do?

@mangupta_amdeng 

