### PR TITLE
test(texture): enable mipmap bind-to-mipmapped-array test on Linux with image support

### DIFF
--- a/catch/unit/texture/hipBindTextureToMipmappedArray.cc
+++ b/catch/unit/texture/hipBindTextureToMipmappedArray.cc
@@ -19,8 +19,8 @@
  */
 texture<float, 2, hipReadModeElementType> texRef;
 
-// MipMap is currently supported only on windows
-#if (defined(_WIN32) && !__HIP_NO_IMAGE_SUPPORT)
+// MipMap is supported on windows and linux with image support
+#if !__HIP_NO_IMAGE_SUPPORT
 __global__ void tex2DKernel(float* outputData, int width, int height, float level) {
   int x = blockIdx.x * blockDim.x + threadIdx.x;
   int y = blockIdx.y * blockDim.y + threadIdx.y;
@@ -127,7 +127,7 @@ HIP_TEST_CASE(Unit_hipTextureMipmapRef2D_Positive_Check) {
   // Height Width Vector
   std::vector<unsigned int> hw_vec = {2048, 1024, 512, 256, 64};
   std::vector<unsigned int> mip_vec = {8, 4, 2, 1};
-#if (defined(_WIN32) && !__HIP_NO_IMAGE_SUPPORT)
+#if !__HIP_NO_IMAGE_SUPPORT
   for (auto& hw : hw_vec) {
     for (auto& mip : mip_vec) {
       if ((hw / static_cast<int>(pow(2, (mip * 2)))) > 0) {
@@ -162,7 +162,7 @@ HIP_TEST_CASE(Unit_hipTextureMipmapRef2D_Positive_Check) {
 HIP_TEST_CASE(Unit_hipTextureMipmapRef2D_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT
 
-#if defined(_WIN32)
+#if (defined(_WIN32) || defined(__linux__))
   unsigned int width = 64;
   unsigned int height = 64;
   unsigned int mipmap_level = 1;


### PR DESCRIPTION
## Associated JIRA ticket number/Github issue number
AILIKFD-9  
https://amd-hub.atlassian.net/browse/AILIKFD-9

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## What were the changes?

- Updated mipmap texture bind test guards to allow Linux execution when image support is available.
- Replaced Windows-only compile-time checks with `!__HIP_NO_IMAGE_SUPPORT` in `hipBindTextureToMipmappedArray.cc`.
- Updated negative-parameter test guard in the same file to include Linux (`_WIN32 || __linux__`).

## Why are these changes needed?

- Mipmap functionality is supported on Linux and Windows when image support is enabled.
- Existing Windows-only guards prevented Linux coverage for this test path.
- This change aligns test coverage with actual platform support and improves APU/Linux validation.

## Updated CHANGELOG?

- [ ] Yes
- [x] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [x] No, Does not apply to this PR.

## Additional Checks

- [x] I have added tests relevant to the introduced functionality, and the unit tests are passing locally.
- [ ] Any dependent changes have been merged.